### PR TITLE
fix(ci): make AI Fix CI runnable manually + add diagnostics

### DIFF
--- a/.github/workflows/ai-fix-ci.yml
+++ b/.github/workflows/ai-fix-ci.yml
@@ -1,11 +1,29 @@
 # AI CI fixer: on CI failure (PRs + main), open/update a PR with fixes and enable squash auto-merge.
 # Does not run on forks. Never pushes to main. Stops after 3 attempts with "needs human" summary.
+#
+# Manual trigger (when workflow_run doesn't fire): Actions → "AI Fix CI" → "Run workflow".
+# Required input: run_id (CI workflow run ID from the failed run URL). Optional: head_branch, head_sha.
+# Permissions: contents: write (push branch), pull-requests: write (open/update PR), actions: read (fetch logs).
 name: AI Fix CI
 
 on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "CI workflow run ID (e.g. from the failed run URL)"
+        required: true
+        type: string
+      head_branch:
+        description: "Branch to fix (default: ref that triggered this run)"
+        required: false
+        type: string
+      head_sha:
+        description: "Commit SHA to checkout (default: SHA for this run)"
+        required: false
+        type: string
 
 # Do not run when the failed run was from a fork (only our repo)
 env:
@@ -16,25 +34,53 @@ jobs:
     name: AI fix and open PR
     runs-on: ubuntu-latest
     if: >
-      github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.repository.full_name == github.repository
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'failure' &&
+       github.event.workflow_run.repository.full_name == github.repository)
     permissions:
       contents: write
       pull-requests: write
       actions: read
 
     steps:
+      - name: Diagnostics (event and workflow_run)
+        run: |
+          echo "## Diagnostics" >> "$GITHUB_STEP_SUMMARY"
+          echo "github.event_name=${{ github.event_name }}"
+          echo "workflow_run.name (if present)=${{ github.event.workflow_run.name || 'N/A' }}"
+          echo "workflow_run.id (if present)=${{ github.event.workflow_run.id || 'N/A' }}"
+          echo "workflow_run.conclusion (if present)=${{ github.event.workflow_run.conclusion || 'N/A' }}"
+          {
+            echo "github.event_name=${{ github.event_name }}"
+            echo "workflow_run.name=${{ github.event.workflow_run.name || 'N/A' }}"
+            echo "workflow_run.id=${{ github.event.workflow_run.id || 'N/A' }}"
+            echo "workflow_run.conclusion=${{ github.event.workflow_run.conclusion || 'N/A' }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Checkout at failing commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.head_sha || github.sha) || github.event.workflow_run.head_sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set branch and attempt
         id: meta
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_RUN_ID: ${{ github.event.inputs.run_id }}
+          INPUT_HEAD_BRANCH: ${{ github.event.inputs.head_branch }}
+          WR_RUN_ID: ${{ github.event.workflow_run.id }}
+          WR_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          RUN_ID="${{ github.event.workflow_run.id }}"
-          HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            RUN_ID="$INPUT_RUN_ID"
+            HEAD_BRANCH="${INPUT_HEAD_BRANCH:-$REF_NAME}"
+          else
+            RUN_ID="$WR_RUN_ID"
+            HEAD_BRANCH="$WR_HEAD_BRANCH"
+          fi
           # If we're already on a ci-fix branch, find existing PR and parse attempt
           if [[ "$HEAD_BRANCH" == ci-fix/* ]]; then
             PR=$(gh pr list --head "$HEAD_BRANCH" --state open --json number,body --jq '.[0]')
@@ -62,6 +108,7 @@ jobs:
             FIX_BRANCH="ci-fix/run-${RUN_ID}"
           fi
           echo "attempt=$ATTEMPT" >> "$GITHUB_OUTPUT"
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
           echo "fix_branch=$FIX_BRANCH" >> "$GITHUB_OUTPUT"
           echo "base_branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
           echo "needs_human=false" >> "$GITHUB_OUTPUT"
@@ -93,7 +140,7 @@ jobs:
         id: fixer
         if: steps.meta.outputs.needs_human != 'true'
         env:
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ID: ${{ steps.meta.outputs.run_id }}
           ATTEMPT: ${{ steps.meta.outputs.attempt }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
Closed per repo cleanup: we are pausing AI Fix CI automation changes until CI/branch rules are stabilized.

If/when we re-enable AI Fix CI, re-open an equivalent PR that adds:
- workflow_dispatch with run_id
- diagnostics output
- explicit permissions

(Original diff was limited to .github/workflows/ai-fix-ci.yml.)