### PR TITLE
Exclude pnpm store from typecheck

### DIFF
--- a/researchflow-production-main/tsconfig.json
+++ b/researchflow-production-main/tsconfig.json
@@ -68,7 +68,9 @@
   "exclude": [
     "node_modules",
     "**/node_modules",
-    "node_modules/.pnpm/**/node_modules/@researchflow/*/**",
+    "node_modules/.pnpm/**",
+    "**/node_modules/.pnpm/**",
+    "node_modules/.pnpm/**/node_modules/@researchflow/**",
     "**/dist",
     "services/web",
     "packages/cli",


### PR DESCRIPTION
## Summary
- expand tsconfig exclude patterns for pnpm store paths
- map @researchflow/manuscript-engine to workspace to avoid pnpm store duplication

## Testing
- pnpm run typecheck (fails: unrelated type errors; no node_modules/.pnpm paths)