### PR TITLE
fix(types): use zod namespace import where z is used as a namespace

### DIFF
--- a/researchflow-production-main/packages/ai-agents/src/types/agent.types.ts
+++ b/researchflow-production-main/packages/ai-agents/src/types/agent.types.ts
@@ -4,7 +4,7 @@
  * Core types for the AI agent system.
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 export interface AgentConfig {
   id: string;

--- a/researchflow-production-main/packages/core/src/agents/types.ts
+++ b/researchflow-production-main/packages/core/src/agents/types.ts
@@ -8,7 +8,7 @@
  * services/worker/src/agents/base/state.py
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // =============================================================================
 // Agent Identifiers and Enums

--- a/researchflow-production-main/packages/core/src/config/__tests__/env-schema.test.ts
+++ b/researchflow-production-main/packages/core/src/config/__tests__/env-schema.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { envSchema, validateEnv, validateEnvSafe, getEnvValidationReport } from '../env-schema';
 

--- a/researchflow-production-main/packages/core/src/config/env-schema.ts
+++ b/researchflow-production-main/packages/core/src/config/env-schema.ts
@@ -6,7 +6,7 @@
  * configuration before any code execution.
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Validates that a string has sufficient entropy for cryptographic use.

--- a/researchflow-production-main/packages/core/src/events/aiInvocation.ts
+++ b/researchflow-production-main/packages/core/src/events/aiInvocation.ts
@@ -7,7 +7,7 @@
  * @module @researchflow/core/events/aiInvocation
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================
 // Enums

--- a/researchflow-production-main/packages/core/src/hub/types.ts
+++ b/researchflow-production-main/packages/core/src/hub/types.ts
@@ -5,7 +5,7 @@
  * including pages, databases, tasks, goals, and timeline projections.
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // =============================================================================
 // Hub Page Schema (Notion-like pages)

--- a/researchflow-production-main/packages/core/types/approval.schema.ts
+++ b/researchflow-production-main/packages/core/types/approval.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod";
 
 export const ApprovalStatus = z.enum([
   "PENDING",

--- a/researchflow-production-main/packages/core/types/chat.ts
+++ b/researchflow-production-main/packages/core/types/chat.ts
@@ -1,7 +1,7 @@
 import { sql } from "drizzle-orm";
 import { pgTable, serial, integer, text, timestamp } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
-import { z } from "zod";
+import * as z from "zod";
 
 export const conversations = pgTable("conversations", {
   id: serial("id").primaryKey(),

--- a/researchflow-production-main/packages/core/types/conference.ts
+++ b/researchflow-production-main/packages/core/types/conference.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 export const PresentationTypeSchema = z.enum([
   'poster',

--- a/researchflow-production-main/packages/core/types/handoff-pack.schema.ts
+++ b/researchflow-production-main/packages/core/types/handoff-pack.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod";
 
 export const HandoffPackType = z.enum([
   "RESEARCH_BRIEF",

--- a/researchflow-production-main/packages/core/types/insights.ts
+++ b/researchflow-production-main/packages/core/types/insights.ts
@@ -6,7 +6,7 @@
  * All events are designed to be PHI-safe (no raw patient data).
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // Import base types from schema (these are exported via schema.ts in index.ts)
 import {

--- a/researchflow-production-main/packages/core/types/literature.ts
+++ b/researchflow-production-main/packages/core/types/literature.ts
@@ -5,7 +5,7 @@
  * orchestrator, worker, and web UI services.
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Supported literature search providers

--- a/researchflow-production-main/packages/core/types/manuscript-ideation.ts
+++ b/researchflow-production-main/packages/core/types/manuscript-ideation.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================================================
 // MANUSCRIPT IDEATION SHARED TYPES

--- a/researchflow-production-main/packages/core/types/organization.ts
+++ b/researchflow-production-main/packages/core/types/organization.ts
@@ -5,7 +5,7 @@
  * for multi-tenant support in ResearchFlow.
  */
 
-import { z } from "zod";
+import * as z from "zod";
 
 // =====================
 // ORG ROLE DEFINITIONS

--- a/researchflow-production-main/packages/core/types/quality.ts
+++ b/researchflow-production-main/packages/core/types/quality.ts
@@ -5,7 +5,7 @@
  * and quality dashboard.
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Column type inference result

--- a/researchflow-production-main/packages/core/types/reproducibility-bundle.schema.ts
+++ b/researchflow-production-main/packages/core/types/reproducibility-bundle.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod";
 
 export const PromptRecordSchema = z.object({
   id: z.string(),

--- a/researchflow-production-main/packages/core/types/research-brief.ts
+++ b/researchflow-production-main/packages/core/types/research-brief.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Enhanced Research Brief Types

--- a/researchflow-production-main/packages/core/types/sap.ts
+++ b/researchflow-production-main/packages/core/types/sap.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 export const ModelTypeSchema = z.enum([
   'linear',

--- a/researchflow-production-main/packages/core/types/schema.ts
+++ b/researchflow-production-main/packages/core/types/schema.ts
@@ -2,7 +2,7 @@ import { sql } from "drizzle-orm";
 import type { InferSelectModel } from "drizzle-orm/table";
 import { pgTable, text, varchar, serial, integer, timestamp, boolean, jsonb } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
-import { z } from "zod";
+import * as z from "zod";
 
 // Import users table from auth models for foreign key references
 import { users, sessions } from "./auth";

--- a/researchflow-production-main/packages/core/types/topic-declaration.ts
+++ b/researchflow-production-main/packages/core/types/topic-declaration.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Topic Declaration Types

--- a/researchflow-production-main/packages/core/types/transparency.ts
+++ b/researchflow-production-main/packages/core/types/transparency.ts
@@ -7,7 +7,7 @@
  * @module @researchflow/core/types/transparency
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================
 // Enums

--- a/researchflow-production-main/packages/core/types/types.ts
+++ b/researchflow-production-main/packages/core/types/types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import * as z from "zod";
 
 export interface ScopeSubsection {
   id: string;

--- a/researchflow-production-main/packages/core/types/workflow.ts
+++ b/researchflow-production-main/packages/core/types/workflow.ts
@@ -5,7 +5,7 @@
  * @packageDocumentation
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // =====================
 // NODE TYPES

--- a/researchflow-production-main/packages/cursor-integration/src/index.ts
+++ b/researchflow-production-main/packages/cursor-integration/src/index.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Cursor IDE Integration Package

--- a/researchflow-production-main/packages/manuscript-engine/src/services/pubmed.service.ts
+++ b/researchflow-production-main/packages/manuscript-engine/src/services/pubmed.service.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 import type { Citation, CitationSourceType, LitSearchResult } from '../types/citation.types';
 

--- a/researchflow-production-main/packages/manuscript-engine/src/types.ts
+++ b/researchflow-production-main/packages/manuscript-engine/src/types.ts
@@ -6,7 +6,7 @@
 
 import type { AIRouterRequest } from '@researchflow/ai-router/types';
 import type { AIRouterResponse } from '@researchflow/ai-router/middleware';
-import { z } from 'zod';
+import * as z from 'zod';
 
 // Re-export all types from the types directory for backward compatibility
 export * from './types/index';

--- a/researchflow-production-main/packages/manuscript-engine/src/types/citation-inserter.types.ts
+++ b/researchflow-production-main/packages/manuscript-engine/src/types/citation-inserter.types.ts
@@ -3,7 +3,7 @@
  * Task T26: Frontend types for in-text citation insertion
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Citation insertion position within manuscript text

--- a/researchflow-production-main/packages/manuscript-engine/src/types/citation.types.ts
+++ b/researchflow-production-main/packages/manuscript-engine/src/types/citation.types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 export const CitationSourceTypeSchema = z.enum([
   'pubmed', 'doi', 'pmcid', 'arxiv', 'isbn', 'url', 'manual'

--- a/researchflow-production-main/packages/manuscript-engine/src/types/data-filter.types.ts
+++ b/researchflow-production-main/packages/manuscript-engine/src/types/data-filter.types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import * as z from 'zod';
 
 export const FilterOperatorSchema = z.enum([
   'equals', 'not_equals', 'greater_than', 'less_than', 'between', 'contains', 'in_list', 'is_null', 'is_not_null'

--- a/researchflow-production-main/packages/manuscript-engine/src/types/figure-table-inserter.types.ts
+++ b/researchflow-production-main/packages/manuscript-engine/src/types/figure-table-inserter.types.ts
@@ -3,7 +3,7 @@
  * Task T49: Types for figure/table insertion in manuscripts
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 export const FigureTypeSchema = z.enum([
   'chart',

--- a/researchflow-production-main/packages/manuscript-engine/src/types/imrad.types.ts
+++ b/researchflow-production-main/packages/manuscript-engine/src/types/imrad.types.ts
@@ -3,7 +3,7 @@
  * Types specific to IMRaD (Introduction, Methods, Results, Discussion) manuscript structure
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // IMRaD Section Type - Core manuscript sections
 export type IMRaDSection =

--- a/researchflow-production-main/packages/manuscript-engine/src/types/manuscript.types.ts
+++ b/researchflow-production-main/packages/manuscript-engine/src/types/manuscript.types.ts
@@ -3,7 +3,7 @@
  * Core types for manuscript creation and management
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 import type { IMRaDSection } from './imrad.types';
 

--- a/researchflow-production-main/packages/manuscript-engine/src/types/search-history.types.ts
+++ b/researchflow-production-main/packages/manuscript-engine/src/types/search-history.types.ts
@@ -3,7 +3,7 @@
  * Task T37: Track literature search history for reproducibility
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Search database sources

--- a/researchflow-production-main/packages/manuscript-engine/src/types/section-reorder.types.ts
+++ b/researchflow-production-main/packages/manuscript-engine/src/types/section-reorder.types.ts
@@ -3,7 +3,7 @@
  * Task T52: Types for manuscript section reordering
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 import type { IMRaDSection } from './imrad.types';
 

--- a/researchflow-production-main/packages/shared/src/schemas/audit_event_v2.ts
+++ b/researchflow-production-main/packages/shared/src/schemas/audit_event_v2.ts
@@ -6,7 +6,7 @@
  * @version 2.0.0
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // Governance Mode
 export const GovernanceModeSchema = z.enum(['DEMO', 'LIVE']);

--- a/researchflow-production-main/packages/shared/src/schemas/evidence_bundle.ts
+++ b/researchflow-production-main/packages/shared/src/schemas/evidence_bundle.ts
@@ -6,7 +6,7 @@
  * @version 1.0.0
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // Performance Metric Schema
 export const PerformanceMetricSchema = z.object({

--- a/researchflow-production-main/packages/shared/src/schemas/faves_result.ts
+++ b/researchflow-production-main/packages/shared/src/schemas/faves_result.ts
@@ -6,7 +6,7 @@
  * @version 1.0.0
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // FAVES Dimension
 export const FAVESDimensionSchema = z.enum(['FAIR', 'APPROPRIATE', 'VALID', 'EFFECTIVE', 'SAFE']);

--- a/researchflow-production-main/packages/shared/src/schemas/source_attributes.ts
+++ b/researchflow-production-main/packages/shared/src/schemas/source_attributes.ts
@@ -6,7 +6,7 @@
  * @version 1.0.0
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // DSI Status
 export const DSIStatusSchema = z.enum(['DRAFT', 'VALIDATED', 'APPROVED', 'DEPRECATED']);

--- a/researchflow-production-main/services/orchestrator/src/bridges/ai-router-bridge.ts
+++ b/researchflow-production-main/services/orchestrator/src/bridges/ai-router-bridge.ts
@@ -13,7 +13,7 @@
  */
 
 import axios, { AxiosError } from 'axios';
-import { z } from 'zod';
+import * as z from 'zod';
 
 // Type definitions
 export interface ModelOptions {

--- a/researchflow-production-main/services/orchestrator/src/config/visualization.config.ts
+++ b/researchflow-production-main/services/orchestrator/src/config/visualization.config.ts
@@ -5,7 +5,7 @@
  * performance limits, security controls, and operational parameters.
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { createLogger } from '../utils/logger';
 

--- a/researchflow-production-main/services/orchestrator/src/middleware/visualization-error-handler.ts
+++ b/researchflow-production-main/services/orchestrator/src/middleware/visualization-error-handler.ts
@@ -6,7 +6,7 @@
  */
 
 import { Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { visualizationConfig } from '../config/visualization.config';
 import { logAction } from '../services/audit-service';

--- a/researchflow-production-main/services/orchestrator/src/routes/ai-agent-proxy.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/ai-agent-proxy.ts
@@ -15,7 +15,7 @@
 import { getModelRouter } from '@researchflow/ai-router';
 import type { AITaskType, ModelTier, QualityCheck } from '@researchflow/ai-router';
 import { Router, type Request, type Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { getWorkerClient } from '../clients/workerClient';
 import { asyncHandler } from '../middleware/asyncHandler';

--- a/researchflow-production-main/services/orchestrator/src/routes/ai-bridge.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/ai-bridge.ts
@@ -10,7 +10,7 @@
 
 import axios from 'axios';
 import { Router, type Request, type Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { getAIBridgeConfig } from '../config/ai-bridge.config';
 import { getBatchOptimizer } from '../middleware/ai-bridge-batch-optimizer';

--- a/researchflow-production-main/services/orchestrator/src/routes/ai-extraction.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/ai-extraction.ts
@@ -9,7 +9,7 @@
 
 import { scan } from '@researchflow/phi-engine';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { generateStructured } from '../../llm-router';
 import { asyncHandler } from '../middleware/asyncHandler';

--- a/researchflow-production-main/services/orchestrator/src/routes/ai-insights.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/ai-insights.ts
@@ -10,7 +10,7 @@
 
 import { Router, Request, Response } from 'express';
 import { v4 as uuid } from 'uuid';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { asyncHandler } from '../middleware/asyncHandler';
 import { logAction } from '../services/audit-service';

--- a/researchflow-production-main/services/orchestrator/src/routes/ai-router.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/ai-router.ts
@@ -9,7 +9,7 @@
  */
 
 import { Router, type Request, type Response, type NextFunction } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { asyncHandler } from '../middleware/asyncHandler';
 import { requirePermission } from '../middleware/rbac';

--- a/researchflow-production-main/services/orchestrator/src/routes/analysis-execution.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/analysis-execution.ts
@@ -10,7 +10,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { config } from '../config/env';
 import { asyncHandler } from '../middleware/asyncHandler';

--- a/researchflow-production-main/services/orchestrator/src/routes/analysis-planning.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/analysis-planning.ts
@@ -5,7 +5,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { asyncHandler } from '../middleware/asyncHandler';
 import { planningService } from '../services/planning';

--- a/researchflow-production-main/services/orchestrator/src/routes/artifact-graph.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/artifact-graph.ts
@@ -8,7 +8,7 @@
  * - GET /api/ros/artifact-edges - List edges for research
  */
 import { Router, Request, Response } from "express";
-import { z } from "zod";
+import * as z from "zod";
 
 import { requireRole } from "../middleware/rbac";
 import * as artifactGraphService from "../services/artifactGraphService";

--- a/researchflow-production-main/services/orchestrator/src/routes/artifact-versions.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/artifact-versions.ts
@@ -14,7 +14,7 @@ import { artifacts, artifactVersions } from "@researchflow/core/schema";
 import { eq, and, desc } from "drizzle-orm";
 import { Router, Request, Response } from "express";
 import { nanoid } from "nanoid";
-import { z } from "zod";
+import * as z from "zod";
 
 import { db } from "../../db";
 import { requireRole } from "../middleware/rbac";

--- a/researchflow-production-main/services/orchestrator/src/routes/auth.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/auth.ts
@@ -8,7 +8,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { logAuthEvent } from '../services/audit-service';
 import {

--- a/researchflow-production-main/services/orchestrator/src/routes/chat-agent.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/chat-agent.ts
@@ -15,7 +15,7 @@
 
 import type { Queue } from 'bullmq';
 import { Router, type Request, type Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { asyncHandler } from '../middleware/asyncHandler';
 import { requirePermission } from '../middleware/rbac';

--- a/researchflow-production-main/services/orchestrator/src/routes/chat.routes.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/chat.routes.ts
@@ -9,7 +9,7 @@
  */
 
 import { Router, Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { chatRepository } from '../repositories/chat.repository';
 import type { ChatSession, ChatMessage, ChatAction } from '../repositories/chat.repository';

--- a/researchflow-production-main/services/orchestrator/src/routes/citations.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/citations.ts
@@ -26,7 +26,7 @@
 import { sql } from 'drizzle-orm';
 import { Router, Request, Response } from 'express';
 import { nanoid } from 'nanoid';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db';
 

--- a/researchflow-production-main/services/orchestrator/src/routes/claims.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/claims.ts
@@ -13,7 +13,7 @@
  * - GET /api/ros/claims/coverage - Get coverage report
  */
 import { Router, Request, Response } from "express";
-import { z } from "zod";
+import * as z from "zod";
 
 import { requireRole } from "../middleware/rbac";
 import { createAuditEntry } from "../services/auditService";

--- a/researchflow-production-main/services/orchestrator/src/routes/collaborationExport.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/collaborationExport.ts
@@ -4,7 +4,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import * as collaborationExportService from '../services/collaborationExportService';
 

--- a/researchflow-production-main/services/orchestrator/src/routes/collections.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/collections.ts
@@ -22,7 +22,7 @@
 
 import { sql } from 'drizzle-orm';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db';
 

--- a/researchflow-production-main/services/orchestrator/src/routes/comments.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/comments.ts
@@ -11,7 +11,7 @@
  * - DELETE /api/ros/comments/:id - Soft delete comment
  */
 import { Router, Request, Response } from "express";
-import { z } from "zod";
+import * as z from "zod";
 
 import { requireRole } from "../middleware/rbac";
 import { createAuditEntry } from "../services/auditService";

--- a/researchflow-production-main/services/orchestrator/src/routes/cumulative-data.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/cumulative-data.ts
@@ -8,7 +8,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import {
   getCumulativeDataService,

--- a/researchflow-production-main/services/orchestrator/src/routes/custom-fields.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/custom-fields.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { asyncHandler } from '../middleware/asyncHandler';
 import { customFieldsService, CustomFieldsSchemaValidator } from '../services/customFieldsService';

--- a/researchflow-production-main/services/orchestrator/src/routes/demo.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/demo.ts
@@ -12,7 +12,7 @@ import {
   type ManuscriptProposal
 } from '@packages/core/types';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 const router = Router();
 

--- a/researchflow-production-main/services/orchestrator/src/routes/docs-first/ideas.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/docs-first/ideas.ts
@@ -5,7 +5,7 @@
  */
 
 import express, { type Request, type Response, type NextFunction } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { asyncHandler } from '../../middleware/asyncHandler.js';
 import { blockInStandby } from '../../middleware/governance-gates.js';

--- a/researchflow-production-main/services/orchestrator/src/routes/docs-first/topic-briefs.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/docs-first/topic-briefs.ts
@@ -7,7 +7,7 @@
 import { docAnchors } from '@researchflow/core/schema';
 import { eq, desc } from 'drizzle-orm';
 import express, { type Request, type Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../lib/db.js';
 import { asyncHandler } from '../../middleware/asyncHandler.js';

--- a/researchflow-production-main/services/orchestrator/src/routes/ecosystem.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/ecosystem.ts
@@ -28,7 +28,7 @@
 
 import { sql } from 'drizzle-orm';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db';
 

--- a/researchflow-production-main/services/orchestrator/src/routes/experiments.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/experiments.ts
@@ -1,7 +1,7 @@
 import { featureFlags, experiments } from '@researchflow/core/types/schema';
 import { eq } from 'drizzle-orm';
 import express from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../lib/db';
 import { asyncHandler } from '../middleware/asyncHandler';

--- a/researchflow-production-main/services/orchestrator/src/routes/export.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/export.ts
@@ -33,7 +33,7 @@ import path from 'path';
 
 import { sql } from 'drizzle-orm';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db';
 import { requireAuth } from '../middleware/auth.js';

--- a/researchflow-production-main/services/orchestrator/src/routes/faves.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/faves.ts
@@ -12,7 +12,7 @@
 
 import { desc, eq, and, sql, gte, lte } from 'drizzle-orm';
 import { Router, Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db.js';
 import { requireRole } from '../middleware/rbac';

--- a/researchflow-production-main/services/orchestrator/src/routes/google-drive.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/google-drive.ts
@@ -6,7 +6,7 @@
 import { orgIntegrations } from '@researchflow/core/types/schema';
 import { eq, and } from 'drizzle-orm';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db';
 import { requireAuth } from '../middleware/governance';

--- a/researchflow-production-main/services/orchestrator/src/routes/governance-simulate.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/governance-simulate.ts
@@ -8,7 +8,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { logAction } from '../services/auditService.js';
 

--- a/researchflow-production-main/services/orchestrator/src/routes/hub/calendar.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/hub/calendar.ts
@@ -6,7 +6,7 @@
 
 import { Router, Request, Response, NextFunction } from 'express';
 import { Pool } from 'pg';
-import { z } from 'zod';
+import * as z from 'zod';
 
 const router = Router();
 

--- a/researchflow-production-main/services/orchestrator/src/routes/hub/databases.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/hub/databases.ts
@@ -7,7 +7,7 @@
 
 import { Router, Request, Response, NextFunction } from 'express';
 import { Pool } from 'pg';
-import { z } from 'zod';
+import * as z from 'zod';
 
 const router = Router();
 

--- a/researchflow-production-main/services/orchestrator/src/routes/hub/goals.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/hub/goals.ts
@@ -7,7 +7,7 @@
 
 import { Router, Request, Response, NextFunction } from 'express';
 import { Pool } from 'pg';
-import { z } from 'zod';
+import * as z from 'zod';
 
 const router = Router();
 

--- a/researchflow-production-main/services/orchestrator/src/routes/hub/milestones.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/hub/milestones.ts
@@ -7,7 +7,7 @@
 
 import { Router, Request, Response, NextFunction } from 'express';
 import { Pool } from 'pg';
-import { z } from 'zod';
+import * as z from 'zod';
 
 const router = Router();
 

--- a/researchflow-production-main/services/orchestrator/src/routes/hub/pages.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/hub/pages.ts
@@ -7,7 +7,7 @@
 
 import { Router, Request, Response, NextFunction } from 'express';
 import { Pool } from 'pg';
-import { z } from 'zod';
+import * as z from 'zod';
 
 const router = Router();
 

--- a/researchflow-production-main/services/orchestrator/src/routes/hub/projections.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/hub/projections.ts
@@ -7,7 +7,7 @@
 
 import { Router, Request, Response, NextFunction } from 'express';
 import { Pool } from 'pg';
-import { z } from 'zod';
+import * as z from 'zod';
 
 const router = Router();
 

--- a/researchflow-production-main/services/orchestrator/src/routes/hub/tasks.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/hub/tasks.ts
@@ -7,7 +7,7 @@
 
 import { Router, Request, Response, NextFunction } from 'express';
 import { Pool } from 'pg';
-import { z } from 'zod';
+import * as z from 'zod';
 
 const router = Router();
 

--- a/researchflow-production-main/services/orchestrator/src/routes/hub/workflow-runs.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/hub/workflow-runs.ts
@@ -7,7 +7,7 @@
 
 import { Router, Request, Response, NextFunction } from 'express';
 import { Pool } from 'pg';
-import { z } from 'zod';
+import * as z from 'zod';
 
 const router = Router();
 

--- a/researchflow-production-main/services/orchestrator/src/routes/ingest.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/ingest.ts
@@ -12,7 +12,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import {
   getMultiFileIngestJob,

--- a/researchflow-production-main/services/orchestrator/src/routes/integrations.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/integrations.ts
@@ -1,6 +1,6 @@
 import { raw } from 'body-parser';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 // Import service modules
 import {

--- a/researchflow-production-main/services/orchestrator/src/routes/integrity.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/integrity.ts
@@ -25,7 +25,7 @@
 
 import { sql } from 'drizzle-orm';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db';
 

--- a/researchflow-production-main/services/orchestrator/src/routes/literature-integrations.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/literature-integrations.ts
@@ -7,7 +7,7 @@ import { orgIntegrations } from '@researchflow/core/types/schema';
 import { ZoteroService, zoteroService } from '@researchflow/manuscript-engine/services';
 import { eq, and } from 'drizzle-orm';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db';
 import { requireAuth } from '../middleware/governance';

--- a/researchflow-production-main/services/orchestrator/src/routes/literature-notes.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/literature-notes.ts
@@ -18,7 +18,7 @@
 
 import { sql } from 'drizzle-orm';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db';
 

--- a/researchflow-production-main/services/orchestrator/src/routes/manuscript-branches.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/manuscript-branches.ts
@@ -12,7 +12,7 @@ import { artifacts, artifactVersions } from "@researchflow/core/schema";
 import { eq, and, desc, sql } from "drizzle-orm";
 import { Router, Request, Response } from "express";
 import { nanoid } from "nanoid";
-import { z } from "zod";
+import * as z from "zod";
 
 import { db } from "../../db";
 import { requireRole } from "../middleware/rbac";

--- a/researchflow-production-main/services/orchestrator/src/routes/manuscript-ideation.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/manuscript-ideation.ts
@@ -12,7 +12,7 @@ import {
   type ManuscriptProposal
 } from '@packages/core/types';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { requireAuth } from '../middleware/governance';
 

--- a/researchflow-production-main/services/orchestrator/src/routes/manuscript/data.routes.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/manuscript/data.routes.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 const router = Router();
 

--- a/researchflow-production-main/services/orchestrator/src/routes/manuscripts.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/manuscripts.ts
@@ -27,7 +27,7 @@ import { createHash } from 'crypto';
 import { sql, eq, desc, and } from 'drizzle-orm';
 import { Router, Request, Response } from 'express';
 import { nanoid } from 'nanoid';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db';
 import { requireRole } from '../middleware/rbac';

--- a/researchflow-production-main/services/orchestrator/src/routes/mesh-lookup.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/mesh-lookup.ts
@@ -8,7 +8,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { asyncHandler } from '../middleware/asyncHandler';
 import { logAction } from '../services/audit-service';

--- a/researchflow-production-main/services/orchestrator/src/routes/monitoring.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/monitoring.ts
@@ -12,7 +12,7 @@
 
 import { desc, eq, and, sql, gte, lte } from 'drizzle-orm';
 import { Router, Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db.js';
 import { requireRole } from '../middleware/rbac';

--- a/researchflow-production-main/services/orchestrator/src/routes/paper-annotations.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/paper-annotations.ts
@@ -21,7 +21,7 @@
 import { sql } from 'drizzle-orm';
 import { Router, Request, Response } from 'express';
 import { nanoid } from 'nanoid';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db';
 

--- a/researchflow-production-main/services/orchestrator/src/routes/paper-copilot.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/paper-copilot.ts
@@ -22,7 +22,7 @@
 
 import { sql } from 'drizzle-orm';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db';
 import { paperCopilotService } from '../services/paper-copilot.service';

--- a/researchflow-production-main/services/orchestrator/src/routes/papers.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/papers.ts
@@ -36,7 +36,7 @@ import { sql, eq, desc, and, ilike, or } from 'drizzle-orm';
 import { Router, Request, Response } from 'express';
 import multer from 'multer';
 import { nanoid } from 'nanoid';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db';
 import { requireAuth } from '../middleware/auth.js';

--- a/researchflow-production-main/services/orchestrator/src/routes/peerReview.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/peerReview.ts
@@ -4,7 +4,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import * as peerReviewService from '../services/peerReviewService';
 

--- a/researchflow-production-main/services/orchestrator/src/routes/phaseChatRoutes.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/phaseChatRoutes.ts
@@ -6,7 +6,7 @@
  */
 
 import { Router, Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import {
   getAgentById,

--- a/researchflow-production-main/services/orchestrator/src/routes/phi-scanner.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/phi-scanner.ts
@@ -9,7 +9,7 @@
  */
 
 import { Router, type Request, type Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { asyncHandler } from '../middleware/asyncHandler';
 import { requirePermission, requireRole } from '../middleware/rbac';

--- a/researchflow-production-main/services/orchestrator/src/routes/preferences.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/preferences.ts
@@ -8,7 +8,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { logAction } from '../services/auditService.js';
 import {

--- a/researchflow-production-main/services/orchestrator/src/routes/projects.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/projects.ts
@@ -6,7 +6,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { pool } from '../../db';
 import { requireAuth } from '../middleware/auth.js';

--- a/researchflow-production-main/services/orchestrator/src/routes/semanticSearch.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/semanticSearch.ts
@@ -11,7 +11,7 @@
  */
 
 import { Router, Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { asyncHandler } from '../middleware/asyncHandler';
 import { requireAuth as isAuthenticated } from '../middleware/auth.js';

--- a/researchflow-production-main/services/orchestrator/src/routes/shares.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/shares.ts
@@ -10,7 +10,7 @@
  * - GET /api/ros/shares/validate - Validate token (public)
  */
 import { Router, Request, Response } from "express";
-import { z } from "zod";
+import * as z from "zod";
 
 import { requireRole } from "../middleware/rbac";
 import { createAuditEntry } from "../services/auditService";

--- a/researchflow-production-main/services/orchestrator/src/routes/source-attributes.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/source-attributes.ts
@@ -12,7 +12,7 @@
 
 import { desc, eq, and, sql, gte, lte, isNull } from 'drizzle-orm';
 import { Router, Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db.js';
 import { requireRole } from '../middleware/rbac';

--- a/researchflow-production-main/services/orchestrator/src/routes/spreadsheet-cell-parse.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/spreadsheet-cell-parse.ts
@@ -10,7 +10,7 @@
 import axios from 'axios';
 import { Router, Request, Response, NextFunction } from 'express';
 import { v4 as uuidv4 } from 'uuid';
-import { z } from 'zod';
+import * as z from 'zod';
 
 const router = Router();
 

--- a/researchflow-production-main/services/orchestrator/src/routes/statistical-analysis.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/statistical-analysis.ts
@@ -12,7 +12,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { config } from '../config/env';
 import { asyncHandler } from '../middleware/asyncHandler';

--- a/researchflow-production-main/services/orchestrator/src/routes/statistical-audit.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/statistical-audit.ts
@@ -13,7 +13,7 @@
  */
 
 import { Router, type Request, type Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { config } from '../config/env';
 import { asyncHandler } from '../middleware/asyncHandler';

--- a/researchflow-production-main/services/orchestrator/src/routes/statistical-recommendations.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/statistical-recommendations.ts
@@ -8,7 +8,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { config } from '../config/env';
 import { asyncHandler } from '../middleware/asyncHandler';

--- a/researchflow-production-main/services/orchestrator/src/routes/submissions.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/submissions.ts
@@ -19,7 +19,7 @@
  * - GET /api/ros/submissions/stats - Get statistics
  */
 import { Router, Request, Response } from "express";
-import { z } from "zod";
+import * as z from "zod";
 
 import { requireRole } from "../middleware/rbac";
 import { createAuditEntry } from "../services/auditService";

--- a/researchflow-production-main/services/orchestrator/src/routes/taskBoards.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/taskBoards.ts
@@ -4,7 +4,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import * as taskBoardService from '../services/taskBoardService';
 

--- a/researchflow-production-main/services/orchestrator/src/routes/transparency.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/transparency.ts
@@ -12,7 +12,7 @@
 
 import { desc, eq, and, sql, gte, lte } from 'drizzle-orm';
 import { Router, Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db.js';
 import { requireRole } from '../middleware/rbac';

--- a/researchflow-production-main/services/orchestrator/src/routes/tutorials.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/tutorials.ts
@@ -6,7 +6,7 @@
  */
 
 import express from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { asyncHandler } from '../middleware/asyncHandler';
 import { featureFlagsService } from '../services/featureFlagsService';

--- a/researchflow-production-main/services/orchestrator/src/routes/user-favorites.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/user-favorites.ts
@@ -7,7 +7,7 @@
 
 import { sql } from 'drizzle-orm';
 import { Router, Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../../db.js';
 import { requireRole } from '../middleware/rbac';

--- a/researchflow-production-main/services/orchestrator/src/routes/user-settings.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/user-settings.ts
@@ -5,7 +5,7 @@
  */
 
 import { Router, type Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { requireAuth } from '../middleware/auth.js';
 

--- a/researchflow-production-main/services/orchestrator/src/routes/v2/artifacts.routes.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/v2/artifacts.routes.ts
@@ -8,7 +8,7 @@
  */
 
 import { Router, Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { requireActiveAccount, requireRole } from '../../middleware/rbac';
 import { ArtifactGraphService } from '../../services/artifact-graph.service';

--- a/researchflow-production-main/services/orchestrator/src/routes/version-control.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/version-control.ts
@@ -6,7 +6,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { config } from '../config/env';
 import { asyncHandler } from '../middleware/asyncHandler';

--- a/researchflow-production-main/services/orchestrator/src/routes/visualization.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/visualization.ts
@@ -16,7 +16,7 @@
 
 import { Router, Request, Response } from 'express';
 import rateLimit from 'express-rate-limit';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { config } from '../config/env';
 import { visualizationConfig, getTimeoutForChartType, validateDataSize } from '../config/visualization.config';

--- a/researchflow-production-main/services/orchestrator/src/routes/watermark.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/watermark.ts
@@ -9,7 +9,7 @@
 
 import { getWatermarkService, WatermarkVerification } from '@researchflow/ai-router/watermark.service';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { logAction } from '../services/auditService.js';
 

--- a/researchflow-production-main/services/orchestrator/src/routes/workflow-stages.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/workflow-stages.ts
@@ -8,7 +8,7 @@
  */
 
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import {
   workflowStageGroups,

--- a/researchflow-production-main/services/orchestrator/src/routes/workflow/stages.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/workflow/stages.ts
@@ -11,7 +11,7 @@ import crypto from 'crypto';
 
 import { Queue } from 'bullmq';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { requireAuth } from '../../middleware/auth';
 import { getEvents, isDone } from '../../services/sse-event-store';

--- a/researchflow-production-main/services/orchestrator/src/routes/workflows.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/workflows.ts
@@ -31,7 +31,7 @@ import {
   type WorkflowPolicy,
 } from '@researchflow/core/types';
 import { Router, Request, Response } from 'express';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { requireRole, logAuditEvent } from '../middleware/rbac';
 import * as workflowService from '../services/workflowService';

--- a/researchflow-production-main/services/orchestrator/src/services/aiModerationService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/aiModerationService.ts
@@ -10,7 +10,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ---------------------------------------------------------------------------
 // Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/aiProviderService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/aiProviderService.ts
@@ -8,7 +8,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ─────────────────────────────────────────────────────────────
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/apiKeyRotationService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/apiKeyRotationService.ts
@@ -11,7 +11,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ─────────────────────────────────────────────────────────────
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/authService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/authService.ts
@@ -17,7 +17,7 @@ import crypto from 'crypto';
 
 import type { Request, Response, NextFunction, RequestHandler } from 'express';
 import type { JwtPayload } from 'jsonwebtoken';
-import { z } from 'zod';
+import * as z from 'zod';
 
 // Import jwt and bcrypt from wrapper module
 // This bypasses tsx module resolution issues with CommonJS packages

--- a/researchflow-production-main/services/orchestrator/src/services/chaosEngineeringService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/chaosEngineeringService.ts
@@ -13,7 +13,7 @@
 
 import { EventEmitter } from 'events';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================================================
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/clusterStatusService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/clusterStatusService.ts
@@ -10,7 +10,7 @@
  * - Node resource utilization
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================================================
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/collaborationExportService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/collaborationExportService.ts
@@ -7,7 +7,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ---------------------------------------------------------------------------
 // Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/communityService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/communityService.ts
@@ -8,7 +8,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ─────────────────────────────────────────────────────────────
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/costMonitoringService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/costMonitoringService.ts
@@ -12,7 +12,7 @@
 
 import { EventEmitter } from 'events';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================================================
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/customFieldsService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/customFieldsService.ts
@@ -1,6 +1,6 @@
 import { orgCustomFields, entityCustomFieldValues, auditLogs } from '@researchflow/core/types/schema';
 import { eq, and, sql } from 'drizzle-orm';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { db } from '../lib/db';
 

--- a/researchflow-production-main/services/orchestrator/src/services/dataImportService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/dataImportService.ts
@@ -11,7 +11,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ─────────────────────────────────────────────────────────────
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/dataShardingService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/dataShardingService.ts
@@ -14,7 +14,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================================================
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/devSimulationService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/devSimulationService.ts
@@ -12,7 +12,7 @@
 
 import { EventEmitter } from 'events';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================================================
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/dockerRegistryService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/dockerRegistryService.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Docker Registry Service Integration

--- a/researchflow-production-main/services/orchestrator/src/services/edgeComputingService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/edgeComputingService.ts
@@ -10,7 +10,7 @@
  * - Provides fallback to central when edge unavailable
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================================================
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/figmaService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/figmaService.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Figma Service Integration

--- a/researchflow-production-main/services/orchestrator/src/services/figures.service.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/figures.service.ts
@@ -6,7 +6,7 @@
  */
 
 import { Pool } from 'pg';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { createLogger } from '../utils/logger';
 

--- a/researchflow-production-main/services/orchestrator/src/services/futureProofingService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/futureProofingService.ts
@@ -11,7 +11,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ─────────────────────────────────────────────────────────────
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/gitSyncService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/gitSyncService.ts
@@ -11,7 +11,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ─────────────────────────────────────────────────────────────
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/googleDriveService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/googleDriveService.ts
@@ -11,7 +11,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ─────────────────────────────────────────────────────────────
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/haToggleService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/haToggleService.ts
@@ -10,7 +10,7 @@
  * - Tracks HA mode state and transitions
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { clusterStatusService } from './clusterStatusService';
 

--- a/researchflow-production-main/services/orchestrator/src/services/lifecycleService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/lifecycleService.ts
@@ -9,7 +9,7 @@
  * @module services/lifecycleService
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // Lifecycle states matching ros-backend/src/governance/lifecycle_states.py
 export const LifecycleStateSchema = z.enum([

--- a/researchflow-production-main/services/orchestrator/src/services/linearService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/linearService.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Linear Service Integration

--- a/researchflow-production-main/services/orchestrator/src/services/metricsCollectorService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/metricsCollectorService.ts
@@ -10,7 +10,7 @@
  * - Job processing durations
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================================================
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/multiCloudService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/multiCloudService.ts
@@ -12,7 +12,7 @@
 
 import { EventEmitter } from 'events';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================================================
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/multiToolOrchestrator.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/multiToolOrchestrator.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 
 import { Queue, Job } from 'bullmq';
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Multi-Tool Orchestration Dispatcher

--- a/researchflow-production-main/services/orchestrator/src/services/notificationService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/notificationService.ts
@@ -7,7 +7,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ---------------------------------------------------------------------------
 // Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/notionService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/notionService.ts
@@ -1,5 +1,5 @@
 import { Client } from '@notionhq/client';
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Enhanced Notion Service Integration

--- a/researchflow-production-main/services/orchestrator/src/services/openApiService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/openApiService.ts
@@ -6,7 +6,7 @@
  * with full schema definitions and examples
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ─────────────────────────────────────────────────────────────
 // Types

--- a/researchflow-production-main/services/orchestrator/src/services/optimizationSuggestionService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/optimizationSuggestionService.ts
@@ -9,7 +9,7 @@
  * - Actionable recommendations with priority ranking
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { haToggleService } from './haToggleService';
 import { metricsCollectorService } from './metricsCollectorService';

--- a/researchflow-production-main/services/orchestrator/src/services/overleafService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/overleafService.ts
@@ -11,7 +11,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ─────────────────────────────────────────────────────────────
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/peerReviewService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/peerReviewService.ts
@@ -7,7 +7,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ---------------------------------------------------------------------------
 // Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/performanceAnalyzerService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/performanceAnalyzerService.ts
@@ -10,7 +10,7 @@
  * - Critical path analysis
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================================================
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/pluginMarketplaceService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/pluginMarketplaceService.ts
@@ -8,7 +8,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ─────────────────────────────────────────────────────────────
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/predictiveScalingService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/predictiveScalingService.ts
@@ -9,7 +9,7 @@
  * - Uses current metrics and HPA configuration for predictions
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 import { clusterStatusService } from './clusterStatusService';
 

--- a/researchflow-production-main/services/orchestrator/src/services/preferences.service.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/preferences.service.ts
@@ -10,7 +10,7 @@
  * Tasks: UI/UX Phase 0 (User Preferences)
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Preference schemas

--- a/researchflow-production-main/services/orchestrator/src/services/productivityAnalyticsService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/productivityAnalyticsService.ts
@@ -5,7 +5,7 @@
  * Security: Only aggregates, no PHI in analytics
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ---------------------------------------------------------------------------
 // Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/schedulerSimulatorService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/schedulerSimulatorService.ts
@@ -10,7 +10,7 @@
  * - What-if scenarios for cluster changes
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================================================
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/scientificNotationService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/scientificNotationService.ts
@@ -9,7 +9,7 @@
  * - SI prefix handling
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ─────────────────────────────────────────────────────────────
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/serverlessTriggerService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/serverlessTriggerService.ts
@@ -12,7 +12,7 @@
 
 import { EventEmitter } from 'events';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================================================
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/slackService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/slackService.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Enhanced Slack Service Integration

--- a/researchflow-production-main/services/orchestrator/src/services/taskBoardService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/taskBoardService.ts
@@ -7,7 +7,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ---------------------------------------------------------------------------
 // Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/teamsService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/teamsService.ts
@@ -8,7 +8,7 @@
  * - Generic webhook support for other platforms
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ─────────────────────────────────────────────────────────────
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/tutorialSandboxService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/tutorialSandboxService.ts
@@ -11,7 +11,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ─────────────────────────────────────────────────────────────
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/verticalScalingService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/verticalScalingService.ts
@@ -10,7 +10,7 @@
  * - Integration with Kubernetes API for actual changes
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ============================================================================
 // Types & Schemas

--- a/researchflow-production-main/services/orchestrator/src/services/videoConferencingService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/videoConferencingService.ts
@@ -7,7 +7,7 @@
 
 import crypto from 'crypto';
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 // ---------------------------------------------------------------------------
 // Schemas

--- a/researchflow-production-main/services/orchestrator/src/types/ambient.d.ts
+++ b/researchflow-production-main/services/orchestrator/src/types/ambient.d.ts
@@ -57,12 +57,6 @@ declare module 'dotenv' {
   export function config(options?: any): any;
 }
 
-// Zod
-declare module 'zod' {
-  export const z: any;
-  export type ZodSchema = any;
-}
-
 // UUID
 declare module 'uuid' {
   export function v4(): string;

--- a/researchflow-production-main/services/orchestrator/src/websocket/events.ts
+++ b/researchflow-production-main/services/orchestrator/src/websocket/events.ts
@@ -13,7 +13,7 @@
  * @module websocket/events
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 
 /**
  * Base WebSocket message schema

--- a/researchflow-production-main/services/web/src/lib/ai-validation.ts
+++ b/researchflow-production-main/services/web/src/lib/ai-validation.ts
@@ -5,7 +5,7 @@
  * Provides runtime type safety and detailed error reporting.
  */
 
-import { z } from 'zod';
+import * as z from 'zod';
 import {
   AIResearchBriefResponseSchema,
   GenerateResearchBriefResponseSchema,


### PR DESCRIPTION
## Summary

- Converted `import { z } from 'zod'` to `import * as z from 'zod'` across **164 files** to enable proper `z.infer<>` namespace resolution
- Removed the ambient `declare module 'zod' { export const z: any }` override in `ambient.d.ts` that was masking Zod's real type definitions — the root cause of all 546 TS2503 errors
- **TS2503 ("Cannot find namespace 'z'") count: 546 → 0**

## Root Cause

The ambient declaration in `services/orchestrator/src/types/ambient.d.ts` was globally overriding Zod's type definitions with `export const z: any`, stripping all namespace capabilities (`z.infer`, `z.ZodSchema`, etc.) across the entire compilation.

## Changes

| Category | Files | Description |
|----------|-------|-------------|
| Import conversion | 164 | `import { z }` → `import * as z` |
| Ambient fix | 1 | Removed `declare module 'zod'` block |

### Scope limited to:
- `packages/**/src/**`
- `services/**/src/**`
- `types/**`

### Not touched (per parallel-safety rules):
- `.github/**`, `vitest.config.ts`, `vitest.integration.config.ts`
- `package.json`, `pnpm-lock.yaml`, `docker-compose*.yml`

## Test plan

- [x] `pnpm run typecheck` — TS2503 reduced from 546 to 0 (1 unrelated `archiver` namespace error remains)
- [ ] Verify no runtime behavior changes (import style only)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)