### PR TITLE
fix(test): resolve @apps/api-node aliases in vitest unit config

### DIFF
--- a/researchflow-production-main/vitest.config.ts
+++ b/researchflow-production-main/vitest.config.ts
@@ -10,6 +10,16 @@ export default defineConfig({
       projects: ['./tsconfig.json'],
     }),
   ],
+  resolve: {
+    alias: {
+      '@apps/api-node/src': fileURLToPath(
+        new URL('./services/orchestrator/src', import.meta.url)
+      ),
+      '@apps/api-node': fileURLToPath(
+        new URL('./services/orchestrator', import.meta.url)
+      ),
+    },
+  },
   test: {
     globals: true,
     environment: 'node',


### PR DESCRIPTION
(Closed) Superseded by the consolidated PR: fix(test): make test:unit unit-only + add @apps/api-node aliases (supersedes #20 #26).