### PR TITLE
test(orchestrator): fix STAGE2_SYNTHESIZE contract fixture

### DIFF
--- a/researchflow-production-main/tests/unit/services/orchestrator/task-contract.test.ts
+++ b/researchflow-production-main/tests/unit/services/orchestrator/task-contract.test.ts
@@ -81,12 +81,32 @@ describe('task-contract', () => {
 
       it('accepts each allowed task type', () => {
         for (const taskType of ALLOWED_TASK_TYPES) {
-          const inputs: Record<string, unknown> =
-            taskType === 'LIT_RETRIEVAL'
-              ? { query: 'q' }
-              : taskType === 'STAGE_2_LITERATURE_REVIEW'
-                ? { research_question: 'rq' }
-                : {};
+          let inputs: Record<string, unknown> = {};
+          
+          // Provide minimal required inputs per task type
+          if (taskType === 'LIT_RETRIEVAL') {
+            inputs = { query: 'q' };
+          } else if (taskType === 'STAGE_2_LITERATURE_REVIEW') {
+            inputs = { research_question: 'rq' };
+          } else if (taskType === 'STAGE2_SYNTHESIZE') {
+            inputs = { papers: [{ id: 'paper-1', title: 'Test Paper' }] };
+          } else if (taskType === 'CLAIM_VERIFY') {
+            inputs = { claims: [{ id: 'claim-1', text: 'Test claim' }] };
+          } else if (
+            taskType === 'SECTION_WRITE_INTRO' ||
+            taskType === 'SECTION_WRITE_METHODS' ||
+            taskType === 'SECTION_WRITE_RESULTS' ||
+            taskType === 'SECTION_WRITE_DISCUSSION'
+          ) {
+            inputs = {
+              outline: { sections: [] },
+              verifiedClaims: [],
+              extractionRows: [],
+              groundingPack: {},
+            };
+          }
+          // STAGE_2_EXTRACT and POLICY_REVIEW accept empty inputs
+          
           const out = buildAndValidateTaskContract({
             request_id: 'r',
             task_type: taskType,


### PR DESCRIPTION
## Summary

Fixes TaskContractValidationError in unit test for task-contract.test.ts

- Add minimal required inputs.papers array for STAGE2_SYNTHESIZE task type
- Add required inputs for all SECTION_WRITE_* task types (outline, verifiedClaims, extractionRows, groundingPack)
- Add required inputs.claims array for CLAIM_VERIFY task type

## Problem

The test "accepts each allowed task type" was iterating through all ALLOWED_TASK_TYPES but only providing specific inputs for LIT_RETRIEVAL and STAGE_2_LITERATURE_REVIEW. When it encountered STAGE2_SYNTHESIZE, SECTION_WRITE_*, and CLAIM_VERIFY task types, it was passing empty inputs, causing validation errors.

## Solution

Updated the test to check each task type and provide the minimal required inputs according to INPUT_REQUIREMENTS in task-contract.ts:
- STAGE2_SYNTHESIZE: papers array
- SECTION_WRITE_*: outline, verifiedClaims, extractionRows, groundingPack
- CLAIM_VERIFY: claims array
- STAGE_2_EXTRACT and POLICY_REVIEW: continue to accept empty inputs

## Test Results

All 16 tests in task-contract.test.ts now pass:

```
✓ tests/unit/services/orchestrator/task-contract.test.ts (16 tests) 4ms
Test Files  1 passed (1)
Tests  16 passed (16)
```

## Related Issue

Fixes failing CI in PR #17 "Lint & test" job


Made with [Cursor](https://cursor.com)