### PR TITLE
ci(worker): fix pip rich dependency conflict

### DIFF
--- a/researchflow-production-main/services/worker/requirements-backup.txt
+++ b/researchflow-production-main/services/worker/requirements-backup.txt
@@ -95,11 +95,11 @@ python-dotenv==1.2.1
 python-jose[cryptography]>=3.3.0  # Security: Algorithm confusion fix (CVE-2024-33664)
 python-multipart>=0.0.7  # Security: Arbitrary file write fix (CVE-2024-24762)
 pytz==2025.2
-PyYAML==6.0.1
+PyYAML>=6.0.2
 referencing==0.37.0
 regex==2025.11.3
 requests==2.32.5
-rich==14.2.0
+rich>=13.7.1,<14
 rpds-py==0.30.0
 rsa==4.9.1
 ruamel.yaml==0.19.1

--- a/researchflow-production-main/services/worker/requirements-base.txt
+++ b/researchflow-production-main/services/worker/requirements-base.txt
@@ -95,11 +95,11 @@ python-dotenv==1.2.1
 python-jose[cryptography]>=3.3.0  # Security: Algorithm confusion fix (CVE-2024-33664)
 python-multipart>=0.0.7  # Security: Arbitrary file write fix (CVE-2024-24762)
 pytz==2025.2
-PyYAML==6.0.1
+PyYAML>=6.0.2
 referencing==0.37.0
 regex==2025.11.3
 requests==2.32.5
-rich==14.2.0
+rich>=13.7.1,<14
 rpds-py==0.30.0
 rsa==4.9.1
 ruamel.yaml==0.19.1

--- a/researchflow-production-main/services/worker/requirements.txt
+++ b/researchflow-production-main/services/worker/requirements.txt
@@ -95,11 +95,11 @@ python-dotenv==1.2.1
 python-jose[cryptography]>=3.3.0  # Security: Algorithm confusion fix (CVE-2024-33664)
 python-multipart>=0.0.7  # Security: Arbitrary file write fix (CVE-2024-24762)
 pytz==2025.2
-PyYAML==6.0.1
+PyYAML>=6.0.2
 referencing==0.37.0
 regex==2025.11.3
 requests==2.32.5
-rich==14.2.0
+rich>=13.7.1,<14
 rpds-py==0.30.0
 rsa==4.9.1
 ruamel.yaml==0.19.1


### PR DESCRIPTION
## Summary
- `composio-core==0.7.0` requires `rich>=13.7.1,<14` and `pyyaml>=6.0.2`, but worker requirements pinned `rich==14.2.0` and `PyYAML==6.0.1`, causing `pip install` to fail with `ResolutionImpossible` in CI.
- Changed `rich==14.2.0` → `rich>=13.7.1,<14` and `PyYAML==6.0.1` → `PyYAML>=6.0.2` in `requirements.txt`, `requirements-base.txt`, and `requirements-backup.txt`.
- Verified: `pip install composio-core==0.7.0 'rich>=13.7.1,<14' 'PyYAML>=6.0.2'` resolves successfully (rich 13.9.4, PyYAML 6.0.3).

## Test plan
- [ ] CI `pip install -r services/worker/requirements.txt` passes without dependency conflict
- [ ] Worker service starts and runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)