### PR TITLE
fix(ai-router): align StreamChunk yields with required shape

### DIFF
--- a/researchflow-production-main/packages/ai-router/src/dispatchers/custom-agent-dispatcher.ts
+++ b/researchflow-production-main/packages/ai-router/src/dispatchers/custom-agent-dispatcher.ts
@@ -254,6 +254,7 @@ export class CustomAgentDispatcher extends EventEmitter {
       yield {
         type: 'error',
         content: `No custom model for task: ${request.taskType}`,
+        done: false,
       };
       return;
     }
@@ -269,8 +270,9 @@ export class CustomAgentDispatcher extends EventEmitter {
       context = this.formatRAGContext(ragContext);
       
       yield {
-        type: 'rag',
+        type: 'metadata',
         content: `Retrieved ${ragContext.results?.length || 0} documents`,
+        done: false,
         metadata: { sources: ragContext.results?.map(r => r.id) },
       };
     }
@@ -312,10 +314,10 @@ export class CustomAgentDispatcher extends EventEmitter {
           try {
             const json = JSON.parse(line);
             if (json.response) {
-              yield { type: 'content', content: json.response };
+              yield { type: 'content', content: json.response, done: false };
             }
             if (json.done) {
-              yield { type: 'done', content: '' };
+              yield { type: 'done', content: '', done: true };
             }
           } catch {
             // Skip invalid JSON lines


### PR DESCRIPTION
## Summary

Fixes TypeScript errors in `custom-agent-dispatcher.ts`:
- **TS2741**: Property 'done' is missing in type 'StreamChunk'
- **TS2322**: Type '"rag"' is not assignable to type '"error" | "metadata" | "content" | "done"'

## Changes

1. Added `done` property to all StreamChunk yields:
   - `done: false` for non-final chunks (error, metadata, content)
   - `done: true` for the final chunk (type: "done")

2. Replaced `type: 'rag'` with `type: 'metadata'` to match the StreamChunk type union

## Files Modified

- `researchflow-production-main/packages/ai-router/src/dispatchers/custom-agent-dispatcher.ts`

## Verification

Ran typecheck to confirm TS2741 and TS2322 errors for `custom-agent-dispatcher.ts` are resolved:

```bash
pnpm -C researchflow-production-main exec tsc -p packages/ai-router/tsconfig.json --noEmit
```

✅ No errors reported for `custom-agent-dispatcher.ts`

## Related

Follows PR #25 in the cleanup series.

Made with [Cursor](https://cursor.com)