### PR TITLE
fix(ai-router): widen ModelTier and request metadata for custom routing

### DIFF
--- a/researchflow-production-main/packages/ai-router/src/types.ts
+++ b/researchflow-production-main/packages/ai-router/src/types.ts
@@ -8,7 +8,7 @@
 /**
  * Model tier classifications for cost-optimized routing
  */
-export type ModelTier = 'LOCAL' | 'NANO' | 'MINI' | 'FRONTIER';
+export type ModelTier = 'LOCAL' | 'NANO' | 'MINI' | 'FRONTIER' | 'CUSTOM';
 
 /**
  * AI task types that determine model tier selection
@@ -75,6 +75,7 @@ export interface AIRouterRequest {
   responseFormat?: 'text' | 'json';
   /** Override the tier selection */
   forceTier?: ModelTier;
+  workflowStage?: number;
   /** Metadata for tracking */
   metadata?: {
     userId?: string;
@@ -82,6 +83,8 @@ export interface AIRouterRequest {
     stageId?: number;
     workflowStep?: string;
     sessionId?: string;
+    projectId?: string;
+    runId?: string;
   };
 }
 


### PR DESCRIPTION
## Summary

Widens `ai-router/types.ts` to fix TypeScript errors blocking custom agent routing:

- Add `'CUSTOM'` to `ModelTier` union
- Add `workflowStage?: number` to `AIRouterRequest`
- Add `projectId?: string` and `runId?: string` to `AIRouterRequest.metadata`

## Changes

**Modified:** `researchflow-production-main/packages/ai-router/src/types.ts`

1. **ModelTier**: Added `'CUSTOM'` to the union type (line 11)
2. **AIRouterRequest**: Added `workflowStage?: number` field (line 78)
3. **Metadata**: Added `projectId?: string` and `runId?: string` fields (lines 86-87)

All new fields are optional.

## Errors Fixed

This PR fixes the following TypeScript errors:

- ✅ TS2322: Type `"CUSTOM"` is not assignable to type `ModelTier`
- ✅ TS2353: Property `workflowStage` does not exist on type `AIRouterRequest`
- ✅ TS2353: Property `projectId` does not exist on type metadata
- ✅ TS2353: Property `runId` does not exist on type metadata

## Next Steps

Follow-up PR will add `CUSTOM` to `MODEL_CONFIGS` and align `custom.ts` dispatcher with these types.

## Testing

```bash
pnpm -C researchflow-production-main exec tsc -p packages/ai-router/tsconfig.json --noEmit
```


Made with [Cursor](https://cursor.com)