### PR TITLE
fix(test): make test:unit truly unit-only

### DIFF
--- a/researchflow-production-main/vitest.config.ts
+++ b/researchflow-production-main/vitest.config.ts
@@ -24,9 +24,13 @@ export default defineConfig({
       '**/node_modules/**',
       'tests/e2e/**',
       'services/web/**',
-      'tests/integration/api-endpoints.test.ts',
-      'tests/integration/artifacts.test.ts',
-      'tests/integration/standby-mode.test.ts',
+      // Exclude integration and governance tests to make test:unit truly unit-only
+      'tests/integration/**',
+      'tests/governance/**',
+      'packages/**/tests/integration/**',
+      'packages/**/__tests__/integration/**',
+      'services/**/tests/integration/**',
+      'services/**/__tests__/integration/**',
     ],
     testTimeout: 10000,
     coverage: {


### PR DESCRIPTION
## Summary

Update `vitest.config.ts` to broadly exclude integration and governance tests from the `test:unit` command.

## Changes

- Added comprehensive exclusion patterns for integration tests:
  - `tests/integration/**`
  - `tests/governance/**`
  - `packages/**/tests/integration/**`
  - `packages/**/__tests__/integration/**`
  - `services/**/tests/integration/**`
  - `services/**/__tests__/integration/**`

## Impact

After this change, `pnpm run test:unit` will:
- ✅ Only run true unit tests
- ❌ Not run `tests/integration/manuscript-engine/writing-tools.test.ts`
- ❌ Not run any other integration or governance tests

This aligns with the decision that unit tests should always exclude integration/governance tests, making the test:unit command more reliable and faster.

## Test Plan

- [x] Verified exclusion patterns cover all integration/governance test locations
- [x] Confirmed change matches intent from PR #26 discussion
- [ ] CI will validate that test:unit passes without integration tests


Made with [Cursor](https://cursor.com)