### PR TITLE
fix(ai-router): namespace-qualify OpenAI and Anthropic SDK types

### DIFF
--- a/researchflow-production-main/packages/ai-router/index.ts
+++ b/researchflow-production-main/packages/ai-router/index.ts
@@ -7,8 +7,7 @@
  */
 /* eslint-disable @typescript-eslint/no-require-imports -- dynamic lazy loading */
 
-// Types (explicit re-exports for consumers and subpath resolution)
-export type { AIRouterRequest, ModelTier, AITaskType } from './src/types';
+// Types
 export * from './src/types';
 
 // Services

--- a/researchflow-production-main/packages/ai-router/src/model-router.service.ts
+++ b/researchflow-production-main/packages/ai-router/src/model-router.service.ts
@@ -8,7 +8,6 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import OpenAI from 'openai';
-import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 
 import {
   getConfig,
@@ -636,7 +635,7 @@ export class ModelRouterService {
 
     const startTime = Date.now();
 
-    const messages: ChatCompletionMessageParam[] = [];
+    const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [];
 
     if (request.systemPrompt) {
       messages.push({

--- a/researchflow-production-main/packages/ai-router/src/notion/notionLogger.ts
+++ b/researchflow-production-main/packages/ai-router/src/notion/notionLogger.ts
@@ -16,10 +16,6 @@ import type { AIProvider, AITaskType, ModelTier } from '../types';
 // ============================================================================
 
 export interface AIUsageLogEntry {
-  /** ISO timestamp when the call was made (optional, for logging) */
-  timestamp?: string;
-  /** Tool/capability name (e.g. mercury-coder) for logging */
-  tool?: string;
   /** Provider name (claude, openai, grok, mercury, etc.) */
   provider: string;
   /** Specific model used (gpt-4o, claude-3-5-sonnet, etc.) */

--- a/researchflow-production-main/packages/ai-router/src/providers/claude.ts
+++ b/researchflow-production-main/packages/ai-router/src/providers/claude.ts
@@ -6,12 +6,7 @@
  */
 
 import Anthropic from '@anthropic-ai/sdk';
-import type {
-  MessageParam,
-  MessageCreateParams,
-  Message,
-  MessageStreamEvent,
-} from '@anthropic-ai/sdk/resources/messages';
+import type { MessageParam, MessageCreateParams, Message } from '@anthropic-ai/sdk/resources/messages';
 
 import { logAIUsage, type AIUsageLogEntry } from '../notion/notionLogger';
 import type { AITaskType, ModelTier } from '../types';
@@ -174,7 +169,7 @@ export class ClaudeProvider {
   async *streamMessage(
     params: Omit<MessageCreateParams, 'model' | 'stream'> & { model?: string },
     options: ClaudeRequestOptions = {}
-  ): AsyncGenerator<MessageStreamEvent, ClaudeResponse, unknown> {
+  ): AsyncGenerator<Anthropic.MessageStreamEvent, ClaudeResponse, unknown> {
     const model = params.model ?? this.defaultModel;
     const startTime = Date.now();
     let inputTokens = 0;

--- a/researchflow-production-main/packages/ai-router/src/providers/openai.ts
+++ b/researchflow-production-main/packages/ai-router/src/providers/openai.ts
@@ -10,7 +10,6 @@ import type {
   ChatCompletionCreateParams,
   ChatCompletionMessageParam,
   ChatCompletion,
-  ChatCompletionChunk,
 } from 'openai/resources/chat/completions';
 
 import { logAIUsage, type AIUsageLogEntry } from '../notion/notionLogger';
@@ -183,7 +182,7 @@ export class OpenAIProvider {
   async *streamChatCompletion(
     params: Omit<ChatCompletionCreateParams, 'model' | 'stream'> & { model?: string },
     options: OpenAIRequestOptions = {}
-  ): AsyncGenerator<ChatCompletionChunk, OpenAIResponse, unknown> {
+  ): AsyncGenerator<OpenAI.Chat.Completions.ChatCompletionChunk, OpenAIResponse, unknown> {
     const model = params.model ?? this.defaultModel;
     const startTime = Date.now();
     let inputTokens = 0;


### PR DESCRIPTION
## Summary
Namespace-qualify SDK types from OpenAI and Anthropic packages to improve type safety and eliminate ambiguous imports.

## Changes
- ✅ Use `OpenAI.Chat.ChatCompletionMessageParam` instead of direct import
- ✅ Use `Anthropic.MessageStreamEvent` instead of direct import  
- ✅ Remove unused type imports (`ChatCompletionChunk`, `MessageStreamEvent`)
- ✅ Simplify ai-router type exports to `export * from './src/types'`
- ✅ Clean up `AIUsageLogEntry` interface (removed optional `timestamp` and `tool` fields)

## Files Modified (5)
- `packages/ai-router/index.ts`
- `packages/ai-router/src/model-router.service.ts`
- `packages/ai-router/src/notion/notionLogger.ts`
- `packages/ai-router/src/providers/claude.ts`
- `packages/ai-router/src/providers/openai.ts`

## Testing
- [x] Unit tests passing
- [x] No behavioral changes
- [x] Type-only refactoring

## Notes
Extracted from original PR #16 (`ci/fix-test-harness-syntax-1`). This PR contains only the safe ai-router type fixes. Test expansions and tsconfig changes were excluded.

**Size**: 5 files, +5/-17 lines (94% smaller than original PR)
