### PR TITLE
fix(proxy): tighten health/ready checks to require 2xx, fail on auth …

### DIFF
--- a/researchflow-production-main/services/agents/agent-artifact-auditor-proxy/app/main.py
+++ b/researchflow-production-main/services/agents/agent-artifact-auditor-proxy/app/main.py
@@ -91,13 +91,23 @@ async def health_ready():
                 f"{settings.langsmith_api_url}/info",
                 headers={"x-api-key": settings.langsmith_api_key}
             )
-            if response.status_code < 500:
-                return {"status": "ready", "langsmith": "reachable"}
-            else:
+            # Special-case auth failures for clarity
+            if response.status_code in (401, 403):
                 raise HTTPException(
                     status_code=503,
-                    detail=f"LangSmith API unhealthy: {response.status_code}"
+                    detail={"status": "not_ready", "langsmith": "auth_failed", "status_code": response.status_code}
                 )
+            # Only 2xx indicates truly ready
+            if 200 <= response.status_code < 300:
+                return {"status": "ready", "langsmith": "reachable"}
+            # Any other non-2xx is not ready
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "status": "not_ready",
+                    "langsmith": {"reachable": False, "status_code": response.status_code}
+                }
+            )
     except httpx.RequestError as e:
         logger.error(f"LangSmith readiness check failed: {e}")
         raise HTTPException(

--- a/researchflow-production-main/services/agents/agent-bias-detection-proxy/app/main.py
+++ b/researchflow-production-main/services/agents/agent-bias-detection-proxy/app/main.py
@@ -91,13 +91,23 @@ async def health_ready():
                 f"{settings.langsmith_api_url}/info",
                 headers={"x-api-key": settings.langsmith_api_key}
             )
-            if response.status_code < 500:
-                return {"status": "ready", "langsmith": "reachable"}
-            else:
+            # Special-case auth failures for clarity
+            if response.status_code in (401, 403):
                 raise HTTPException(
                     status_code=503,
-                    detail=f"LangSmith API unhealthy: {response.status_code}"
+                    detail={"status": "not_ready", "langsmith": "auth_failed", "status_code": response.status_code}
                 )
+            # Only 2xx indicates truly ready
+            if 200 <= response.status_code < 300:
+                return {"status": "ready", "langsmith": "reachable"}
+            # Any other non-2xx is not ready
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "status": "not_ready",
+                    "langsmith": {"reachable": False, "status_code": response.status_code}
+                }
+            )
     except httpx.RequestError as e:
         logger.error(f"LangSmith readiness check failed: {e}")
         raise HTTPException(

--- a/researchflow-production-main/services/agents/agent-clinical-manuscript-proxy/app/main.py
+++ b/researchflow-production-main/services/agents/agent-clinical-manuscript-proxy/app/main.py
@@ -91,13 +91,23 @@ async def health_ready():
                 f"{settings.langsmith_api_url}/info",
                 headers={"x-api-key": settings.langsmith_api_key}
             )
-            if response.status_code < 500:
-                return {"status": "ready", "langsmith": "reachable"}
-            else:
+            # Special-case auth failures for clarity
+            if response.status_code in (401, 403):
                 raise HTTPException(
                     status_code=503,
-                    detail=f"LangSmith API unhealthy: {response.status_code}"
+                    detail={"status": "not_ready", "langsmith": "auth_failed", "status_code": response.status_code}
                 )
+            # Only 2xx indicates truly ready
+            if 200 <= response.status_code < 300:
+                return {"status": "ready", "langsmith": "reachable"}
+            # Any other non-2xx is not ready
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "status": "not_ready",
+                    "langsmith": {"reachable": False, "status_code": response.status_code}
+                }
+            )
     except httpx.RequestError as e:
         logger.error(f"LangSmith readiness check failed: {e}")
         raise HTTPException(

--- a/researchflow-production-main/services/agents/agent-compliance-auditor-proxy/app/main.py
+++ b/researchflow-production-main/services/agents/agent-compliance-auditor-proxy/app/main.py
@@ -91,13 +91,23 @@ async def health_ready():
                 f"{settings.langsmith_api_url}/info",
                 headers={"x-api-key": settings.langsmith_api_key}
             )
-            if response.status_code < 500:
-                return {"status": "ready", "langsmith": "reachable"}
-            else:
+            # Special-case auth failures for clarity
+            if response.status_code in (401, 403):
                 raise HTTPException(
                     status_code=503,
-                    detail=f"LangSmith API unhealthy: {response.status_code}"
+                    detail={"status": "not_ready", "langsmith": "auth_failed", "status_code": response.status_code}
                 )
+            # Only 2xx indicates truly ready
+            if 200 <= response.status_code < 300:
+                return {"status": "ready", "langsmith": "reachable"}
+            # Any other non-2xx is not ready
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "status": "not_ready",
+                    "langsmith": {"reachable": False, "status_code": response.status_code}
+                }
+            )
     except httpx.RequestError as e:
         logger.error(f"LangSmith readiness check failed: {e}")
         raise HTTPException(

--- a/researchflow-production-main/services/agents/agent-dissemination-formatter-proxy/app/main.py
+++ b/researchflow-production-main/services/agents/agent-dissemination-formatter-proxy/app/main.py
@@ -91,13 +91,23 @@ async def health_ready():
                 f"{settings.langsmith_api_url}/info",
                 headers={"x-api-key": settings.langsmith_api_key}
             )
-            if response.status_code < 500:
-                return {"status": "ready", "langsmith": "reachable"}
-            else:
+            # Special-case auth failures for clarity
+            if response.status_code in (401, 403):
                 raise HTTPException(
                     status_code=503,
-                    detail=f"LangSmith API unhealthy: {response.status_code}"
+                    detail={"status": "not_ready", "langsmith": "auth_failed", "status_code": response.status_code}
                 )
+            # Only 2xx indicates truly ready
+            if 200 <= response.status_code < 300:
+                return {"status": "ready", "langsmith": "reachable"}
+            # Any other non-2xx is not ready
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "status": "not_ready",
+                    "langsmith": {"reachable": False, "status_code": response.status_code}
+                }
+            )
     except httpx.RequestError as e:
         logger.error(f"LangSmith readiness check failed: {e}")
         raise HTTPException(

--- a/researchflow-production-main/services/agents/agent-journal-guidelines-cache-proxy/app/main.py
+++ b/researchflow-production-main/services/agents/agent-journal-guidelines-cache-proxy/app/main.py
@@ -91,13 +91,23 @@ async def health_ready():
                 f"{settings.langsmith_api_url}/info",
                 headers={"x-api-key": settings.langsmith_api_key}
             )
-            if response.status_code < 500:
-                return {"status": "ready", "langsmith": "reachable"}
-            else:
+            # Special-case auth failures for clarity
+            if response.status_code in (401, 403):
                 raise HTTPException(
                     status_code=503,
-                    detail=f"LangSmith API unhealthy: {response.status_code}"
+                    detail={"status": "not_ready", "langsmith": "auth_failed", "status_code": response.status_code}
                 )
+            # Only 2xx indicates truly ready
+            if 200 <= response.status_code < 300:
+                return {"status": "ready", "langsmith": "reachable"}
+            # Any other non-2xx is not ready
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "status": "not_ready",
+                    "langsmith": {"reachable": False, "status_code": response.status_code}
+                }
+            )
     except httpx.RequestError as e:
         logger.error(f"LangSmith readiness check failed: {e}")
         raise HTTPException(

--- a/researchflow-production-main/services/agents/agent-performance-optimizer-proxy/app/main.py
+++ b/researchflow-production-main/services/agents/agent-performance-optimizer-proxy/app/main.py
@@ -91,13 +91,23 @@ async def health_ready():
                 f"{settings.langsmith_api_url}/info",
                 headers={"x-api-key": settings.langsmith_api_key}
             )
-            if response.status_code < 500:
-                return {"status": "ready", "langsmith": "reachable"}
-            else:
+            # Special-case auth failures for clarity
+            if response.status_code in (401, 403):
                 raise HTTPException(
                     status_code=503,
-                    detail=f"LangSmith API unhealthy: {response.status_code}"
+                    detail={"status": "not_ready", "langsmith": "auth_failed", "status_code": response.status_code}
                 )
+            # Only 2xx indicates truly ready
+            if 200 <= response.status_code < 300:
+                return {"status": "ready", "langsmith": "reachable"}
+            # Any other non-2xx is not ready
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "status": "not_ready",
+                    "langsmith": {"reachable": False, "status_code": response.status_code}
+                }
+            )
     except httpx.RequestError as e:
         logger.error(f"LangSmith readiness check failed: {e}")
         raise HTTPException(

--- a/researchflow-production-main/services/agents/agent-section-drafter-proxy/app/main.py
+++ b/researchflow-production-main/services/agents/agent-section-drafter-proxy/app/main.py
@@ -91,13 +91,23 @@ async def health_ready():
                 f"{settings.langsmith_api_url}/info",
                 headers={"x-api-key": settings.langsmith_api_key}
             )
-            if response.status_code < 500:
-                return {"status": "ready", "langsmith": "reachable"}
-            else:
+            # Special-case auth failures for clarity
+            if response.status_code in (401, 403):
                 raise HTTPException(
                     status_code=503,
-                    detail=f"LangSmith API unhealthy: {response.status_code}"
+                    detail={"status": "not_ready", "langsmith": "auth_failed", "status_code": response.status_code}
                 )
+            # Only 2xx indicates truly ready
+            if 200 <= response.status_code < 300:
+                return {"status": "ready", "langsmith": "reachable"}
+            # Any other non-2xx is not ready
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "status": "not_ready",
+                    "langsmith": {"reachable": False, "status_code": response.status_code}
+                }
+            )
     except httpx.RequestError as e:
         logger.error(f"LangSmith readiness check failed: {e}")
         raise HTTPException(


### PR DESCRIPTION
…errors

- Change /health/ready to only return 2xx for truly ready state
- Special-case 401/403 as auth_failed (not generic 5xx)
- Prevents orchestrator from routing to misconfigured proxies
- Affects 10 LangSmith proxy agents

Rationale: Previous logic accepted any <500 status as ready, including 4xx client errors. This caused routing to agents with invalid credentials or configuration issues. New logic enforces 2xx-only readiness.