### PR TITLE
fix(ws): move event websocket path to /ws/events

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/websocket/server.ts
+++ b/researchflow-production-main/services/orchestrator/src/websocket/server.ts
@@ -48,7 +48,9 @@ interface ClientConnection {
 }
 
 /**
- * WebSocket server configuration
+ * WebSocket server configuration.
+ * Default path is /ws/events so this event-broadcast server can coexist with the
+ * existing collaboration WebSocket server that uses /ws.
  */
 interface WebSocketServerConfig {
   path?: string;
@@ -71,7 +73,7 @@ export class WebSocketEventServer {
 
   constructor(config: WebSocketServerConfig = {}) {
     this.config = {
-      path: config.path || '/ws',
+      path: config.path || '/ws/events',
       heartbeatIntervalMs: config.heartbeatIntervalMs || 30000, // 30 seconds
       heartbeatTimeoutMs: config.heartbeatTimeoutMs || 60000, // 60 seconds
       maxConnections: config.maxConnections || 10000,


### PR DESCRIPTION
# Summary
- What changed?
- Why?

## AI Review Link / Status (optional)
- [ ] AI review comment posted (link it here): <!-- paste URL to the AI review comment/thread -->
- Notes/overrides (if any):

## Security / PHI checklist
- [ ] No PHI in logs, screenshots, test fixtures, or example payloads
- [ ] Secrets not added (env files, configs, tests); rotated if exposed
- [ ] AuthN/AuthZ reviewed for new/changed access paths
- [ ] Input validation + safe error handling for new endpoints/queues/jobs

## Auditability checklist (when writing data)
- [ ] Any write path emits an audit event via `AuditService.appendEvent`
- [ ] Actor + tenant/org context captured (who did what, where/when)
- [ ] Audit event includes stable identifiers (not raw PHI)

## DB migration checklist (if applicable)
- [ ] Migration included + reversible (up/down) where supported
- [ ] Backfill/rollout plan documented (online vs offline, batching)
- [ ] Indexes/constraints validated; expected perf impact considered
