### PR TITLE
fix(ci): run strict typecheck from researchflow-production-main

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -16,6 +16,9 @@ jobs:
   typecheck:
     name: TypeScript strict check
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: researchflow-production-main
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
Updates the Strict Typecheck workflow to run pnpm commands from the researchflow-production-main directory using defaults.run.working-directory.

Made with [Cursor](https://cursor.com)