### PR TITLE
fix(ci): run strict typecheck from researchflow-production-main

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -16,6 +16,9 @@ jobs:
   typecheck:
     name: TypeScript strict check
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: researchflow-production-main
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -38,7 +41,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('researchflow-production-main/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 


### PR DESCRIPTION
## Summary

- Add `defaults.run.working-directory: researchflow-production-main` to the **Strict Typecheck** workflow so `pnpm install` and `pnpm run typecheck` execute inside the correct subdirectory.
- Update `hashFiles` path in the cache key from `pnpm-lock.yaml` to `researchflow-production-main/pnpm-lock.yaml` (hashFiles resolves from repo root).

## Test plan

- [ ] CI "TypeScript strict check" job passes on this PR
- [ ] pnpm install finds `pnpm-lock.yaml` in `researchflow-production-main/`
- [ ] Cache key correctly hashes the lockfile at the new path

Made with [Cursor](https://cursor.com)