### PR TITLE
fix(ci): run strict typecheck from researchflow-production-main

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -16,6 +16,9 @@ jobs:
   typecheck:
     name: TypeScript strict check
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: researchflow-production-main
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -38,7 +41,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('researchflow-production-main/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 


### PR DESCRIPTION
## Summary
- Run Strict Typecheck workflow `pnpm` commands from `researchflow-production-main/` via job-level `defaults.run.working-directory`.
- Update cache key to hash the `researchflow-production-main/pnpm-lock.yaml` lockfile.

## Test plan
- [ ] Confirm the **Strict Typecheck** workflow runs on this PR and executes `pnpm install` + `pnpm run typecheck` from `researchflow-production-main/`.


Made with [Cursor](https://cursor.com)