### PR TITLE
fix(types): add workflow schema exports

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/types/researchflow-core.d.ts
+++ b/researchflow-production-main/services/orchestrator/src/types/researchflow-core.d.ts
@@ -29,6 +29,11 @@ declare module '@researchflow/core/schema' {
   export const chatMessages: any;
   export const shares: any;
   export const papers: any;
+  export const workflows: any;
+  export const workflowVersions: any;
+  export const workflowTemplates: any;
+  export const workflowPolicies: any;
+  export const workflowRunCheckpoints: any;
   
   // Additional table exports for orchestrator
   export const researchProjects: any;


### PR DESCRIPTION
## Summary
- add missing workflow table exports to @researchflow/core/schema ambient typings
- keep change limited to schema surface for orchestrator types

## Testing
- pnpm -C researchflow-production-main run typecheck (fails: existing unrelated errors)