### PR TITLE
fix(types): add phi-engine ambient exports

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/types/researchflow-core.d.ts
+++ b/researchflow-production-main/services/orchestrator/src/types/researchflow-core.d.ts
@@ -153,6 +153,12 @@ declare module '@researchflow/phi-engine' {
   export const scanForPHI: (text: string) => Promise<any>;
   export const redact: (text: string, detections: any) => string;
   export const detectPHI: (data: any) => Promise<any[]>;
+  export const containsPhi: (text: string) => boolean;
+  export const getPhiStats: (text: string) => Record<string, number>;
+  export const scrubLog: (text: string) => string;
+  export const scrubObject: (obj: any) => any;
+  export const scan: (text: string) => Promise<any>;
+  export const hasPhi: (text: string) => boolean;
   export class PHIEngine {
     scan(text: string): Promise<any>;
     redact(text: string): Promise<string>;


### PR DESCRIPTION
## Summary
- add missing @researchflow/phi-engine ambient exports used by orchestrator
- include scan/hasPhi aliases plus scrub/contains helpers

## Testing
- pnpm -C researchflow-production-main run typecheck (fails: existing unrelated errors)

## Typecheck Counts
- before: 1200 errors in 244 files
- after: 1195 errors in 242 files