### PR TITLE
fix(types): restore websocket typing surface (ping)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/types/ambient.d.ts
+++ b/researchflow-production-main/services/orchestrator/src/types/ambient.d.ts
@@ -73,6 +73,7 @@ declare module 'ws' {
     readyState: number;
     send(data: any, cb?: any): void;
     close(code?: number, reason?: string): void;
+    ping(data?: any, mask?: boolean, cb?: any): void;
     terminate(): void;
   }
   export class WebSocketServer extends EventEmitter {


### PR DESCRIPTION
## Summary
- Add `ping` to the ws WebSocket ambient type so the existing usage in orchestrator types checks.

## Typecheck
- main: 1162 errors / 237 files
- PR63: 1161 errors / 236 files

## Eliminated WebSocket errors
- services/orchestrator/src/websocket/manager.ts: `TS2339 Property 'ping' does not exist on type 'WebSocket'`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only change that broadens the ambient `ws` surface to match runtime usage; no behavioral or runtime code paths are affected.
> 
> **Overview**
> Restores the missing `ping()` method on the ambient `ws` `WebSocket` type in `services/orchestrator/src/types/ambient.d.ts`, unblocking TypeScript checks for existing heartbeat/health usage (e.g., `client.ws.ping()`).
> 
> No runtime logic changes; this PR only updates the TypeScript declaration surface for the `ws` module.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d198fe9656302603b28e5fe5b19efe511669ead8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->