### PR TITLE
PR64 Prompt

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/types/ambient.d.ts
+++ b/researchflow-production-main/services/orchestrator/src/types/ambient.d.ts
@@ -70,16 +70,23 @@ declare module 'ws' {
   export class WebSocket extends EventEmitter {
     static OPEN: number;
     static CLOSED: number;
+    readonly OPEN: number;
+    readonly CLOSED: number;
     readyState: number;
     send(data: any, cb?: any): void;
     close(code?: number, reason?: string): void;
     ping(data?: any, mask?: boolean, cb?: any): void;
     terminate(): void;
   }
+  export namespace WebSocket {
+    type RawData = any;
+    type Data = any;
+  }
   export class WebSocketServer extends EventEmitter {
     constructor(options: any);
     clients: Set<WebSocket>;
     close(cb?: any): void;
+    handleUpgrade(request: any, socket: any, head: any, cb: (client: WebSocket) => void): void;
   }
   export default WebSocket;
 }


### PR DESCRIPTION
## Typecheck\n- main: 1161 errors / 236 files\n- PR64: 1157 errors / 236 files (Δ -4 / 0)\n\n## Eliminated errors (single root cause: ws/platform typings)\n- TS2339: handleUpgrade missing on WebSocketServer (services/orchestrator/src/index.ts)\n- TS2576: OPEN missing on WebSocket instances (services/orchestrator/src/index.ts)\n- TS2702: WebSocket used as namespace (WebSocket.Data) (services/orchestrator/src/langchain-bridge.ts)\n\n## Changed files\n- services/orchestrator/src/types/ambient.d.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only changes to the local `ws` ambient declarations; runtime behavior is unaffected and risk is limited to potential masking of real `ws` API mismatches.
> 
> **Overview**
> Updates the orchestrator’s ambient `ws` TypeScript declarations to match how the code uses the library.
> 
> Adds instance `OPEN`/`CLOSED` constants on `WebSocket`, introduces the `WebSocket` namespace types (`WebSocket.Data`/`RawData`), and declares `WebSocketServer.handleUpgrade(...)` to resolve existing typecheck errors in WebSocket proxy/bridge code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb89a19e9ba02c84d4312ae695c86ea15d9f7576. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->