### PR TITLE
fix(types): narrow governance reason unions

### DIFF
--- a/researchflow-production-main/tests/governance/standby-external-calls.test.ts
+++ b/researchflow-production-main/tests/governance/standby-external-calls.test.ts
@@ -8,6 +8,13 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { BlockReason } from '../../services/orchestrator/src/utils/telemetry';
+
+type AICallAllowedResult = { allowed: true } | { allowed: false; reason: BlockReason };
+
+function isBlocked(result: AICallAllowedResult): result is { allowed: false; reason: BlockReason } {
+  return result.allowed === false;
+}
 
 // Mock the telemetry module to test without actual environment
 const mockEnv = {
@@ -68,7 +75,7 @@ describe('STANDBY Mode External Call Blocking', () => {
       const result = checkAICallAllowed();
 
       expect(result.allowed).toBe(false);
-      if (!result.allowed) {
+      if (isBlocked(result)) {
         expect(result.reason).toBe('standby_mode');
       }
     });
@@ -80,7 +87,7 @@ describe('STANDBY Mode External Call Blocking', () => {
       const result = checkAICallAllowed();
 
       expect(result.allowed).toBe(false);
-      if (!result.allowed) {
+      if (isBlocked(result)) {
         expect(result.reason).toBe('standby_mode');
       }
     });
@@ -92,7 +99,7 @@ describe('STANDBY Mode External Call Blocking', () => {
       const result = checkAICallAllowed();
 
       expect(result.allowed).toBe(false);
-      if (!result.allowed) {
+      if (isBlocked(result)) {
         expect(result.reason).toBe('no_network');
       }
     });
@@ -123,7 +130,7 @@ describe('STANDBY Mode External Call Blocking', () => {
       const result = checkAICallAllowed();
 
       expect(result.allowed).toBe(false);
-      if (!result.allowed) {
+      if (isBlocked(result)) {
         expect(result.reason).toBe('standby_mode');
       }
     });
@@ -286,7 +293,7 @@ describe('STANDBY Mode External Call Blocking', () => {
       const result = checkAICallAllowed();
 
       expect(result.allowed).toBe(false);
-      if (!result.allowed) {
+      if (isBlocked(result)) {
         expect(result.reason).toBe('no_network');
       }
     });


### PR DESCRIPTION
Before: 1157 errors / 236 files
After (pnpm -C researchflow-production-main run typecheck): 1156 errors / 235 files (Δ -1 / -1)

Eliminated errors:
- TS2339 in tests/governance/standby-external-calls.test.ts (5x result.reason)

Changed files:
- tests/governance/standby-external-calls.test.ts

Process fix (run every time): ran `pnpm -C researchflow-production-main run typecheck` and recorded authoritative counts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test/type-narrowing only; no production code paths or governance enforcement logic are modified.
> 
> **Overview**
> Updates `standby-external-calls.test.ts` to make blocked-call assertions type-safe by importing `BlockReason`, defining an `AICallAllowedResult` union, and using an `isBlocked` type guard before reading `result.reason` in multiple test cases.
> 
> This is a **test-only** change aimed at eliminating TypeScript narrowing errors; runtime behavior and telemetry logic are unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06900343544bd2402acb697c0a2c2a5ba2e999cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->