### PR TITLE
fix(types): narrow governance result unions (next cluster)

### DIFF
--- a/researchflow-production-main/tests/security/insights-phi-scan.test.ts
+++ b/researchflow-production-main/tests/security/insights-phi-scan.test.ts
@@ -33,8 +33,24 @@ const PHI_PATTERNS = {
   NAME_PATTERN: /\b(patient|name)[:\s]+[A-Z][a-z]+\s+[A-Z][a-z]+\b/i,
 };
 
+type InsightsEvent = {
+  id: string;
+  timestamp: string;
+  governance_mode: 'LIVE' | 'DEMO' | 'STANDBY';
+  project_id: string;
+  tier: string;
+  status: string;
+  run_id: string;
+  stage: number;
+  agent_id: string;
+  user_id: string;
+  tenant_id: string;
+  input?: string;
+  output?: string;
+};
+
 // Sample events for testing
-const createTestEvent = (overrides = {}) => ({
+const createTestEvent = (overrides: Partial<InsightsEvent> = {}): InsightsEvent => ({
   id: 'evt_123',
   timestamp: new Date().toISOString(),
   governance_mode: 'LIVE' as const,


### PR DESCRIPTION
Before: 1156 errors / 235 files
After:  1150 errors / 234 files

Eliminated errors:
- TS2339: tests/security/insights-phi-scan.test.ts

Changed files:
- tests/security/insights-phi-scan.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only TypeScript typing change with no runtime behavior impact; risk is limited to potential test compilation/type-checking adjustments.
> 
> **Overview**
> This PR fixes TypeScript errors in `tests/security/insights-phi-scan.test.ts` by introducing a typed `InsightsEvent` shape and updating `createTestEvent` to accept `Partial<InsightsEvent>` overrides and return a fully-typed event.
> 
> The change narrows the `governance_mode` field to a specific union (`'LIVE' | 'DEMO' | 'STANDBY'`) and adds optional `input`/`output` fields to align the test data with expected event properties.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 496e693816dbaebcd379091aeb11eacf348e0890. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->