### PR TITLE
ResearchFlow Stabilization — PR70: align test mock roles with AuthUser typing

### DIFF
--- a/researchflow-production-main/tests/utils/rbac-mock.ts
+++ b/researchflow-production-main/tests/utils/rbac-mock.ts
@@ -10,19 +10,28 @@ import type { Request, Response, NextFunction } from 'express';
 
 import type { Role } from '../../packages/core/types/roles';
 
+type AuthUserRole = 'admin' | 'researcher' | 'reviewer' | 'viewer';
+
+const ROLE_TO_AUTH_ROLE: Record<Role, AuthUserRole> = {
+  VIEWER: 'viewer',
+  RESEARCHER: 'researcher',
+  STEWARD: 'reviewer',
+  ADMIN: 'admin',
+};
+
 export interface MockUser {
   id: string;
   username: string;
-  role: Role;
+  role: AuthUserRole;
   email: string;
   isActive: boolean;
 }
 
 export const TEST_USERS: Record<Role, MockUser> = {
-  VIEWER: { id: 'test-viewer-001', username: 'test_viewer', role: 'VIEWER', email: 'viewer@test.com', isActive: true },
-  RESEARCHER: { id: 'test-researcher-001', username: 'test_researcher', role: 'RESEARCHER', email: 'researcher@test.com', isActive: true },
-  STEWARD: { id: 'test-steward-001', username: 'test_steward', role: 'STEWARD', email: 'steward@test.com', isActive: true },
-  ADMIN: { id: 'test-admin-001', username: 'test_admin', role: 'ADMIN', email: 'admin@test.com', isActive: true },
+  VIEWER: { id: 'test-viewer-001', username: 'test_viewer', role: ROLE_TO_AUTH_ROLE.VIEWER, email: 'viewer@test.com', isActive: true },
+  RESEARCHER: { id: 'test-researcher-001', username: 'test_researcher', role: ROLE_TO_AUTH_ROLE.RESEARCHER, email: 'researcher@test.com', isActive: true },
+  STEWARD: { id: 'test-steward-001', username: 'test_steward', role: ROLE_TO_AUTH_ROLE.STEWARD, email: 'steward@test.com', isActive: true },
+  ADMIN: { id: 'test-admin-001', username: 'test_admin', role: ROLE_TO_AUTH_ROLE.ADMIN, email: 'admin@test.com', isActive: true },
 };
 
 /**


### PR DESCRIPTION
## Authoritative Gate
pnpm -C researchflow-production-main run typecheck

## Baseline (main)
Before: 1115 errors / 228 files

## Result (this PR)
After: 1112 errors / 225 files

## Eliminated Errors (must be specific)
- TS2322: tests/integration/api-endpoints.test.ts (count: 1)
- TS2322: tests/integration/conference-endpoints.test.ts (count: 1)
- TS2322: tests/utils/rbac-mock.ts (count: 1)

## Changed Files
- tests/utils/rbac-mock.ts

## Scope / Safety
This PR is tests-only and/or types-only and introduces no runtime behavior change.
One conceptual root cause only; no schema refactors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests-only type alignment that doesn’t change production auth/RBAC behavior; risk is limited to potentially breaking assumptions in tests expecting `role` to be a core `Role` value.
> 
> **Overview**
> Updates RBAC test utilities to **use auth-layer role strings** instead of core `Role` enum values for `req.user.role`.
> 
> Introduces an `AuthUserRole` union and a `Role`→`AuthUserRole` mapping, and updates `TEST_USERS` to populate the mapped role values to resolve TypeScript assignment errors in integration tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0027ad0cddb809ac67a8042e8e95fae109bd77f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->