### PR TITLE
PR76: Fix duplicate primitive exports

### DIFF
--- a/researchflow-production-main/packages/ui/src/primitives/index.ts
+++ b/researchflow-production-main/packages/ui/src/primitives/index.ts
@@ -20,13 +20,3 @@ export {
 export { Modal, type ModalProps } from './Modal';
 export { Table, type TableProps, type Column, type SortDirection } from './Table';
 export { Tabs, TabPanel, type TabsProps, type TabPanelProps, type Tab } from './Tabs';
-
-// Re-export defaults
-export { default as Button } from './Button';
-export { default as Badge } from './Badge';
-export { default as Alert } from './Alert';
-export { default as Input } from './Input';
-export { default as Card } from './Card';
-export { default as Modal } from './Modal';
-export { default as Table } from './Table';
-export { default as Tabs } from './Tabs';


### PR DESCRIPTION
Command: pnpm -C researchflow-production-main run typecheck
Before: 1043 errors / 221 files
After: 1027 errors / 220 files
Eliminated: TS2300 (16) in packages/ui/src/primitives/index.ts
Changed files: packages/ui/src/primitives/index.ts only
Statement: types/barrel-only; no runtime behavior change; single root cause; no schema refactors; no suppressions; minimal diff
