### PR TITLE
Fix duplicate governance barrel exports (PR77)

### DIFF
--- a/researchflow-production-main/packages/ui/src/governance/index.ts
+++ b/researchflow-production-main/packages/ui/src/governance/index.ts
@@ -1,31 +1,25 @@
 // Governance Components
-export { 
-  PHIGateBanner, 
-  type PHIGateBannerProps, 
-  type PHIStatus 
+export {
+  default as PHIGateBanner,
+  type PHIGateBannerProps,
+  type PHIStatus,
 } from './PHIGateBanner';
 
-export { 
-  ModelTierBadge, 
-  type ModelTierBadgeProps, 
-  type ModelTier 
+export {
+  default as ModelTierBadge,
+  type ModelTierBadgeProps,
+  type ModelTier,
 } from './ModelTierBadge';
 
-export { 
-  TransparencyPanel, 
-  type TransparencyPanelProps, 
-  type TransparencyData 
+export {
+  default as TransparencyPanel,
+  type TransparencyPanelProps,
+  type TransparencyData,
 } from './TransparencyPanel';
 
 export {
-  ApprovalStatusIndicator,
+  default as ApprovalStatusIndicator,
   type ApprovalStatusIndicatorProps,
   type ApprovalDetails,
   type ApprovalStatus,
 } from './ApprovalStatusIndicator';
-
-// Re-export defaults
-export { default as PHIGateBanner } from './PHIGateBanner';
-export { default as ModelTierBadge } from './ModelTierBadge';
-export { default as TransparencyPanel } from './TransparencyPanel';
-export { default as ApprovalStatusIndicator } from './ApprovalStatusIndicator';


### PR DESCRIPTION
## Description
Deduplicate governance barrel exports so each identifier is exported once.

## Typecheck
Command: `pnpm -C researchflow-production-main run typecheck`
Before: 1027 errors / 220 files
After: 1019 errors / 220 files
Eliminated TS2300 count (governance/index.ts): 8

## Changed File
- packages/ui/src/governance/index.ts

Standard statement: Types/barrel-only change; no runtime behavior changes.
