### PR TITLE
PR78: Remove duplicate route imports in orchestrator index

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/index.ts
+++ b/researchflow-production-main/services/orchestrator/src/index.ts
@@ -143,8 +143,6 @@ import transparencyRoutes from './routes/transparency';  // Transparency and aud
 import integrationsStorageRoutes from './routes/integrations-storage';  // Integration data persistence
 
 // Transparency & Compliance Routes (Phase 10)
-import favesRoutes from './routes/faves';  // FAVES compliance tracking
-import transparencyRoutes from './routes/transparency';  // Evidence bundles & model registry
 import monitoringRoutes from './routes/monitoring';  // Drift & bias monitoring
 
 // Phase 3: Secondary Routes (Integration Plan)


### PR DESCRIPTION
Command: pnpm -C researchflow-production-main run typecheck
Before: 1019 errors / 219 files
After: 1015 errors / 219 files
Eliminated: TS2300 (4) in services/orchestrator/src/index.ts
Changed files: services/orchestrator/src/index.ts only
Statement: types/wiring-only; no runtime behavior change beyond removing accidental duplicate declarations; single root cause; no schema refactors; no suppressions; minimal diff