### PR TITLE
fix(orchestrator): remove duplicate correlationId identifier in logger.ts

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/utils/logger.ts
+++ b/researchflow-production-main/services/orchestrator/src/utils/logger.ts
@@ -17,7 +17,6 @@ interface LogContext {
   module?: string;
   requestId?: string;
   correlationId?: string;
-  correlationId?: string;
   userId?: string;
   [key: string]: unknown;
 }


### PR DESCRIPTION
## ResearchFlow TypeScript Stabilization — PR80

**Command:** `pnpm -C researchflow-production-main run typecheck`
**Before:** 1013 errors / 219 files
**After:** 1011 errors / 218 files
**Eliminated:** TS2300 (2) in `services/orchestrator/src/utils/logger.ts`
**Changed files:** `services/orchestrator/src/utils/logger.ts` only

**Statement:** types/wiring-only; no runtime behavior change; single root cause; no schema refactors; no suppressions; minimal diff

---

### Root cause

The `LogContext` interface in `logger.ts` contained a duplicate `correlationId?: string` property declaration (lines 19–20), producing two TS2300 "Duplicate identifier" errors.

### Fix

Removed the second (duplicate) declaration. Single-line deletion, no other changes.

Made with [Cursor](https://cursor.com)