### PR TITLE
PR80: Fix duplicate correlationId identifier in logger.ts

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/utils/logger.ts
+++ b/researchflow-production-main/services/orchestrator/src/utils/logger.ts
@@ -17,7 +17,6 @@ interface LogContext {
   module?: string;
   requestId?: string;
   correlationId?: string;
-  correlationId?: string;
   userId?: string;
   [key: string]: unknown;
 }


### PR DESCRIPTION
## TypeScript Stabilization — PR80

**Command:** `pnpm -C researchflow-production-main run typecheck`
**Before:** 1013 errors / 212 files
**After:** 1011 errors / 211 files
**Eliminated:** TS2300 (2) in `services/orchestrator/src/utils/logger.ts`
**Changed files:** `services/orchestrator/src/utils/logger.ts` only

**Statement:** types/wiring-only; no runtime behavior change; single root cause; no schema refactors; no suppressions; minimal diff

---

### Root cause

The `LogContext` interface in `logger.ts` contained two identical lines:

```ts
correlationId?: string;
correlationId?: string;
```

This produced 2 × TS2300 "Duplicate identifier 'correlationId'" errors.

### Fix

Removed the duplicate line (1 deletion, 0 additions of logic).

### Verification

- `pnpm -C researchflow-production-main run typecheck` confirms strict error reduction (1013 → 1011 errors, 212 → 211 files).
- `logger.ts` is now error-free (zero grep matches post-fix).
- No runtime, logging, or behavioral changes.

Made with [Cursor](https://cursor.com)