### PR TITLE
fix(tests): make vitest skip boolean

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/__tests__/commits-endpoints.test.ts
+++ b/researchflow-production-main/services/orchestrator/src/__tests__/commits-endpoints.test.ts
@@ -17,7 +17,7 @@ import branchPersistenceService from '../services/branch-persistence.service';
 const hasDb = !!pool;
 let dbAvailable = false;
 
-describe('commits endpoints', { skip: !hasDb ? 'DATABASE_URL not set' : false }, () => {
+describe('commits endpoints', { skip: !hasDb }, () => {
   let testBranchId: string;
   let testManuscriptId: string;
   let initialCommitId: string;

--- a/researchflow-production-main/services/orchestrator/src/__tests__/migrations/018_manuscript_branch_commits.test.ts
+++ b/researchflow-production-main/services/orchestrator/src/__tests__/migrations/018_manuscript_branch_commits.test.ts
@@ -16,7 +16,7 @@ import { dbAvailable } from '../helpers/dbAvailable';
 
 const hasDb = await dbAvailable();
 
-describe('018_manuscript_branch_commits', { skip: !hasDb ? 'DB unavailable or unreachable' : false }, () => {
+describe('018_manuscript_branch_commits', { skip: !hasDb }, () => {
   let testBranchId: string;
   const testManuscriptId = randomUUID();
 

--- a/researchflow-production-main/services/orchestrator/src/__tests__/migrations/019_commit_diffs.test.ts
+++ b/researchflow-production-main/services/orchestrator/src/__tests__/migrations/019_commit_diffs.test.ts
@@ -17,7 +17,7 @@ import { dbAvailable } from '../helpers/dbAvailable';
 
 const hasDb = await dbAvailable();
 
-describe('019_commit_diffs', { skip: !hasDb ? 'DB unavailable or unreachable' : false }, () => {
+describe('019_commit_diffs', { skip: !hasDb }, () => {
   let testBranchId: string;
   const testManuscriptId = randomUUID();
 

--- a/researchflow-production-main/services/orchestrator/src/routes/__tests__/commits-endpoints.test.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/__tests__/commits-endpoints.test.ts
@@ -32,7 +32,7 @@ function createApp() {
   return app;
 }
 
-describe('commits endpoints (routes)', { skip: !hasDb ? 'DATABASE_URL not set' : false }, () => {
+describe('commits endpoints (routes)', { skip: !hasDb }, () => {
   let app: ReturnType<typeof createApp>;
   let testBranchId: string;
   let testManuscriptId: string;

--- a/researchflow-production-main/services/orchestrator/src/services/__tests__/audit-ledger.service.test.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/__tests__/audit-ledger.service.test.ts
@@ -20,7 +20,7 @@ let dbReady = false;
 const HEX_HASH_REGEX = /^[a-f0-9]{64}$/;
 
 describe('AuditLedger service (integration)', {
-  skip: !hasDb ? 'DATABASE_URL not set' : false,
+  skip: !hasDb,
 }, () => {
   beforeAll(async () => {
     if (!hasDb) return;

--- a/researchflow-production-main/services/orchestrator/src/services/__tests__/edit-session.service.test.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/__tests__/edit-session.service.test.ts
@@ -74,7 +74,7 @@ async function cleanup(manuscriptId: string, branchId?: string | null, sessionId
   }
 }
 
-describe('EditSession service (integration)', { skip: !hasDb ? 'DATABASE_URL not set' : false }, () => {
+describe('EditSession service (integration)', { skip: !hasDb }, () => {
   beforeAll(async () => {
     if (!hasDb) return;
     dbReady = await checkDbAvailable();


### PR DESCRIPTION
Command: pnpm -C researchflow-production-main run typecheck
Before: 1011 errors / 218 files
After: 1005 errors / 212 files
Eliminated: TS2769 (6) in tests (services/orchestrator/src/__tests__/commits-endpoints.test.ts; services/orchestrator/src/__tests__/migrations/018_manuscript_branch_commits.test.ts; services/orchestrator/src/__tests__/migrations/019_commit_diffs.test.ts; services/orchestrator/src/routes/__tests__/commits-endpoints.test.ts; services/orchestrator/src/services/__tests__/audit-ledger.service.test.ts; services/orchestrator/src/services/__tests__/edit-session.service.test.ts)
Changed files: services/orchestrator/src/__tests__/commits-endpoints.test.ts; services/orchestrator/src/__tests__/migrations/018_manuscript_branch_commits.test.ts; services/orchestrator/src/__tests__/migrations/019_commit_diffs.test.ts; services/orchestrator/src/routes/__tests__/commits-endpoints.test.ts; services/orchestrator/src/services/__tests__/audit-ledger.service.test.ts; services/orchestrator/src/services/__tests__/edit-session.service.test.ts
Statement: tests-only; no runtime behavior change; single root cause; no schema refactors; no suppressions; minimal diff