### PR TITLE
Fix axe-core a11y matcher types

### DIFF
--- a/researchflow-production-main/tests/e2e/accessibility/helpers/a11y-matchers.ts
+++ b/researchflow-production-main/tests/e2e/accessibility/helpers/a11y-matchers.ts
@@ -3,26 +3,14 @@
  * Wraps axe results and DOM checks for WCAG 2.1 AA compliance.
  */
 
-import type { Result as AxeResult } from 'axe-core';
+import type { Result as AxeResult, AxeResults as AxeCoreResults } from 'axe-core';
 import { expect } from '@playwright/test';
 
 export type AxeImpact = 'critical' | 'serious' | 'moderate' | 'minor';
 
-export interface AxeViolation {
-  id: string;
-  impact?: AxeImpact;
-  description: string;
-  help: string;
-  helpUrl: string;
-  nodes: Array<{ html: string; target: string[] }>;
-}
+export type AxeViolation = AxeResult;
 
-export interface AxeResults {
-  violations: AxeViolation[];
-  passes: AxeResult[];
-  incomplete: AxeResult[];
-  inapplicable: AxeResult[];
-}
+export type AxeResults = AxeCoreResults;
 
 /** Thresholds: 0 critical, 0 serious per WCAG 2.1 AA */
 export const A11Y_THRESHOLDS = {


### PR DESCRIPTION
Command: pnpm -C researchflow-production-main run typecheck
Before: 1005 errors / 212 files
After: 1001 errors / 211 files
Eliminated: TS2345 (4) in tests/e2e/accessibility/axe-core.spec.ts
Changed files: tests/e2e/accessibility/helpers/a11y-matchers.ts
Statement: tests-only; no runtime behavior change; single root cause; no schema refactors; no suppressions; minimal diff