### PR TITLE
PR85: Align IRB proposal typing

### DIFF
--- a/researchflow-production-main/services/orchestrator/ai-research.ts
+++ b/researchflow-production-main/services/orchestrator/ai-research.ts
@@ -614,7 +614,12 @@ export interface IRBProposalResult {
   studySummary: string;
   background: string;
   objectives: { primary: string; secondary: string[] };
-  studyDesign: string;
+  studyDesign: {
+    designType: string;
+    duration: string;
+    setting: string;
+    phases?: string[];
+  };
   population: {
     inclusion: string[];
     exclusion: string[];
@@ -624,6 +629,7 @@ export interface IRBProposalResult {
     sources: string[];
     variables: string[];
     timeline: string;
+    methods?: string[];
   };
   riskAssessment: {
     riskLevel: 'minimal' | 'moderate' | 'greater than minimal';


### PR DESCRIPTION
Command: pnpm -C researchflow-production-main run typecheck
Before: 1000 errors / 210 files
After: 994 errors / 210 files
Eliminated: TS2339 (6) in services/orchestrator/routes.ts by updating IRBProposalResult typing in services/orchestrator/ai-research.ts
Changed files: services/orchestrator/ai-research.ts
Statement: types-only or tests-only; no runtime behavior change; single root cause; no schema refactors; no suppressions; minimal diff