### PR TITLE
fix(tests): relax aria label count assertions

### DIFF
--- a/researchflow-production-main/tests/e2e/statistical-analysis-workflow.spec.ts
+++ b/researchflow-production-main/tests/e2e/statistical-analysis-workflow.spec.ts
@@ -313,8 +313,10 @@ test.describe('Statistical Analysis Workflow', () => {
 
     await test.step('Check ARIA labels', async () => {
       // Verify important elements have proper ARIA labels
-      await expect(page.locator('[aria-label]')).toHaveCount({ min: 5 });
-      await expect(page.locator('[role="tab"]')).toHaveCount({ min: 4 });
+      const ariaLabelCount = await page.locator('[aria-label]').count();
+      const tabCount = await page.locator('[role="tab"]').count();
+      expect(ariaLabelCount).toBeGreaterThanOrEqual(5);
+      expect(tabCount).toBeGreaterThanOrEqual(4);
     });
   });
 


### PR DESCRIPTION
Command: pnpm -C researchflow-production-main run typecheck 2>&1 | tee typecheck.out
Before: 992 errors / 210 files
After: 990 errors / 209 files
Eliminated: TS2345 (2) in tests/e2e/statistical-analysis-workflow.spec.ts
Changed files: tests/e2e/statistical-analysis-workflow.spec.ts
Statement: tests-only; no runtime behavior change; single root cause; no schema refactors; no suppressions; minimal diff