### PR TITLE
PR88: Fix docs-first db import paths

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/routes/__tests__/faves.test.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/__tests__/faves.test.ts
@@ -12,7 +12,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import favesRoutes from '../faves';
 
 // Mock dependencies
-vi.mock('../../db.js', () => ({
+vi.mock('../../../db.js', () => ({
   db: {
     execute: vi.fn(),
   },
@@ -46,7 +46,7 @@ describe('FAVES API Routes', () => {
 
   describe('GET /api/faves/evaluations', () => {
     it('should return list of evaluations', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       
       (db.execute as any).mockResolvedValueOnce({
         rows: [
@@ -76,7 +76,7 @@ describe('FAVES API Routes', () => {
     });
 
     it('should accept query parameters', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       
       (db.execute as any).mockResolvedValue({ rows: [] });
 
@@ -91,7 +91,7 @@ describe('FAVES API Routes', () => {
 
   describe('GET /api/faves/evaluations/:id', () => {
     it('should return evaluation details', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       const evalId = '550e8400-e29b-41d4-a716-446655440000';
       
       (db.execute as any)
@@ -119,7 +119,7 @@ describe('FAVES API Routes', () => {
     });
 
     it('should return 404 for non-existent evaluation', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       
       (db.execute as any).mockResolvedValue({ rows: [] });
 
@@ -133,7 +133,7 @@ describe('FAVES API Routes', () => {
 
   describe('POST /api/faves/evaluations', () => {
     it('should create new evaluation', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       const { eventBus } = await import('../../services/event-bus');
       
       const newEval = {
@@ -181,7 +181,7 @@ describe('FAVES API Routes', () => {
     });
 
     it('should return 400 if model not found', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       
       (db.execute as any).mockResolvedValue({ rows: [] });
 
@@ -200,7 +200,7 @@ describe('FAVES API Routes', () => {
 
   describe('POST /api/faves/evaluations/:id/dimensions', () => {
     it('should submit dimension results', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       const { eventBus } = await import('../../services/event-bus');
       const evalId = '550e8400-e29b-41d4-a716-446655440000';
       
@@ -284,7 +284,7 @@ describe('FAVES API Routes', () => {
     });
 
     it('should return 404 if evaluation not found', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       
       (db.execute as any).mockResolvedValue({ rows: [] });
 
@@ -299,7 +299,7 @@ describe('FAVES API Routes', () => {
 
   describe('POST /api/faves/evaluations/:id/artifacts', () => {
     it('should add artifacts to evaluation', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       const evalId = '550e8400-e29b-41d4-a716-446655440000';
       
       const artifacts = [
@@ -340,7 +340,7 @@ describe('FAVES API Routes', () => {
 
   describe('GET /api/faves/gate/:modelId', () => {
     it('should check deployment gate for model', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       const modelId = '660e8400-e29b-41d4-a716-446655440001';
       
       (db.execute as any).mockResolvedValue({
@@ -374,7 +374,7 @@ describe('FAVES API Routes', () => {
     });
 
     it('should return no evaluation status if not evaluated', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       const modelId = '660e8400-e29b-41d4-a716-446655440999';
       
       (db.execute as any).mockResolvedValue({ rows: [] });
@@ -388,7 +388,7 @@ describe('FAVES API Routes', () => {
     });
 
     it('should flag stale evaluations', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       const modelId = '660e8400-e29b-41d4-a716-446655440001';
       
       // Evaluation from 91 days ago
@@ -417,7 +417,7 @@ describe('FAVES API Routes', () => {
 
   describe('POST /api/faves/gate/:modelId/override', () => {
     it('should request gate override', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       const { eventBus } = await import('../../services/event-bus');
       const modelId = '660e8400-e29b-41d4-a716-446655440001';
       
@@ -469,7 +469,7 @@ describe('FAVES API Routes', () => {
 
   describe('GET /api/faves/stats', () => {
     it('should return FAVES statistics', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       
       // Mock stats query
       (db.execute as any).mockResolvedValueOnce({
@@ -507,7 +507,7 @@ describe('FAVES API Routes', () => {
 
   describe('GET /api/faves/models/:modelId/history', () => {
     it('should return evaluation history for model', async () => {
-      const { db } = await import('../../db.js');
+      const { db } = await import('../../../db.js');
       const modelId = '660e8400-e29b-41d4-a716-446655440001';
       
       (db.execute as any).mockResolvedValue({

--- a/researchflow-production-main/services/orchestrator/src/routes/docs-first/topic-briefs.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/docs-first/topic-briefs.ts
@@ -9,7 +9,7 @@ import { eq, desc } from 'drizzle-orm';
 import express, { type Request, type Response } from 'express';
 import * as z from 'zod';
 
-import { db } from '../../lib/db.js';
+import { db } from '../../../db.js';
 import { asyncHandler } from '../../middleware/asyncHandler.js';
 import { blockInStandby } from '../../middleware/governance-gates.js';
 import { requirePermission, requireRole } from '../../middleware/rbac.js';

--- a/researchflow-production-main/services/orchestrator/src/routes/docs-first/venues.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/docs-first/venues.ts
@@ -8,7 +8,7 @@ import { venues, type Venue } from '@researchflow/core/schema';
 import { eq, and } from 'drizzle-orm';
 import express, { type Request, type Response } from 'express';
 
-import { db } from '../../lib/db.js';
+import { db } from '../../../db.js';
 import { asyncHandler } from '../../middleware/asyncHandler.js';
 import { blockInStandby } from '../../middleware/governance-gates.js';
 import { requirePermission, requireRole } from '../../middleware/rbac.js';

--- a/researchflow-production-main/services/orchestrator/src/services/docs-first/doc-kits.service.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/docs-first/doc-kits.service.ts
@@ -8,7 +8,7 @@
 import { docKits, docKitItems, venues, type DocKit, type DocKitItem } from '@researchflow/core/schema';
 import { eq, and, sql } from 'drizzle-orm';
 
-import { db } from '../../lib/db.js';
+import { db } from '../../../db.js';
 import { createAuditEntry } from '../auditService.js';
 
 export class DocKitsService {

--- a/researchflow-production-main/services/orchestrator/src/services/docs-first/ideas.service.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/docs-first/ideas.service.ts
@@ -8,7 +8,7 @@
 import { ideas, ideaScorecards, topicBriefs, type Idea, type IdeaScorecard, type InsertIdea } from '@researchflow/core/schema';
 import { eq, and, desc, sql } from 'drizzle-orm';
 
-import { db } from '../../lib/db.js';
+import { db } from '../../../db.js';
 import { createAuditEntry } from '../auditService.js';
 
 export class IdeasService {

--- a/researchflow-production-main/services/orchestrator/src/services/docs-first/scope-freeze.service.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/docs-first/scope-freeze.service.ts
@@ -10,7 +10,7 @@ import crypto from 'crypto';
 import { topicBriefs, docAnchors, type DocAnchor } from '@researchflow/core/schema';
 import { eq, desc } from 'drizzle-orm';
 
-import { db } from '../../lib/db.js';
+import { db } from '../../../db.js';
 import { createAuditEntry } from '../auditService.js';
 
 

--- a/researchflow-production-main/services/orchestrator/src/services/docs-first/topic-briefs.service.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/docs-first/topic-briefs.service.ts
@@ -8,7 +8,7 @@
 import { topicBriefs, type TopicBrief, type InsertTopicBrief } from '@researchflow/core/schema';
 import { eq, and, desc, sql } from 'drizzle-orm';
 
-import { db } from '../../lib/db.js';
+import { db } from '../../../db.js';
 import { createAuditEntry } from '../auditService.js';
 
 export class TopicBriefsService {


### PR DESCRIPTION
## Summary\n- Fix incorrect db import paths in docs-first routes/services and faves tests.\n\n## Typecheck (pnpm -C researchflow-production-main run typecheck)\n- Before: 990 errors / 209 files\n- After: 969 errors / 209 files\n- Delta: -21 errors / 0 files\n\n## Notes\n- Root cause: invalid relative db import paths (../../db.js, ../../lib/db.js) in tests and docs-first modules.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F88&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->