### PR TITLE
PR96: Add eventType to logAction call sites

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/middleware/visualization-error-handler.ts
+++ b/researchflow-production-main/services/orchestrator/src/middleware/visualization-error-handler.ts
@@ -417,6 +417,7 @@ export class VisualizationErrorHandler {
       logAction({
         userId: req.user?.id || 'anonymous',
         action: 'SECURITY_ERROR',
+        eventType: 'SECURITY_ERROR',
         resourceType: 'visualization',
         resourceId: req.body?.research_id || 'unknown',
         metadata: {

--- a/researchflow-production-main/services/orchestrator/src/routes/ai-extraction.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/ai-extraction.ts
@@ -80,6 +80,7 @@ router.post(
         await logAction({
           userId: req.user?.id || 'anonymous',
           action: 'PHI_BLOCKED',
+          eventType: 'PHI_BLOCKED',
           resourceType: 'ai_extraction',
           resourceId: requestId,
           metadata: {
@@ -144,6 +145,7 @@ router.post(
       await logAction({
         userId: req.user?.id || 'anonymous',
         action: 'AI_EXTRACTION',
+        eventType: 'AI_EXTRACTION',
         resourceType: 'ai_extraction',
         resourceId: requestId,
         metadata: {

--- a/researchflow-production-main/services/orchestrator/src/routes/analysis-execution.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/analysis-execution.ts
@@ -125,6 +125,7 @@ router.post(
       await logAction({
         userId: req.user?.id || 'anonymous',
         action: 'CLINICAL_EXTRACTION',
+        eventType: 'CLINICAL_EXTRACTION',
         resourceType: 'analysis',
         resourceId: requestId,
         metadata: {
@@ -223,6 +224,7 @@ router.post(
       await logAction({
         userId: req.user?.id || 'anonymous',
         action: 'RUN_ANALYSIS',
+        eventType: 'RUN_ANALYSIS',
         resourceType: 'analysis',
         resourceId: requestId,
         metadata: {

--- a/researchflow-production-main/services/orchestrator/src/routes/export-ris.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/export-ris.ts
@@ -177,6 +177,7 @@ router.post(
     await logAction({
       userId: user.id,
       action: 'EXPORT_RIS',
+      eventType: 'EXPORT_RIS',
       resourceType: 'literature',
       resourceId: `export_${Date.now()}`,
       metadata: {

--- a/researchflow-production-main/services/orchestrator/src/routes/integrations-storage.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/integrations-storage.ts
@@ -138,6 +138,7 @@ router.post(
     await logAction({
       userId: user.id,
       action: 'UPLOAD_TO_BOX',
+      eventType: 'UPLOAD_TO_BOX',
       resourceType: 'file',
       resourceId: fileEntry.id,
       metadata: {
@@ -277,6 +278,7 @@ router.post(
     await logAction({
       userId: user.id,
       action: 'UPLOAD_TO_DROPBOX',
+      eventType: 'UPLOAD_TO_DROPBOX',
       resourceType: 'file',
       resourceId: uploadData.id,
       metadata: {

--- a/researchflow-production-main/services/orchestrator/src/routes/mesh-lookup.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/mesh-lookup.ts
@@ -103,6 +103,7 @@ router.post(
     await logAction({
       userId: req.user?.id || 'anonymous',
       action: 'MESH_LOOKUP',
+      eventType: 'MESH_LOOKUP',
       resourceType: 'literature',
       resourceId: `mesh_batch_${Date.now()}`,
       metadata: {

--- a/researchflow-production-main/services/orchestrator/src/routes/version-control.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/version-control.ts
@@ -147,6 +147,7 @@ router.post(
       await logAction({
         userId: req.user?.id || parseResult.data.owner_id,
         action: 'CREATE_VERSION_PROJECT',
+        eventType: 'CREATE_VERSION_PROJECT',
         resourceType: 'version_project',
         resourceId: parseResult.data.project_id,
         metadata: {
@@ -269,6 +270,7 @@ router.post(
       await logAction({
         userId: req.user?.id || 'anonymous',
         action: 'VERSION_COMMIT',
+        eventType: 'VERSION_COMMIT',
         resourceType: 'version_project',
         resourceId: parseResult.data.project_id,
         metadata: {
@@ -408,6 +410,7 @@ router.post(
       await logAction({
         userId: req.user?.id || 'anonymous',
         action: 'VERSION_RESTORE',
+        eventType: 'VERSION_RESTORE',
         resourceType: 'version_project',
         resourceId: parseResult.data.project_id,
         metadata: {
@@ -467,6 +470,7 @@ router.post(
       await logAction({
         userId: req.user?.id || 'anonymous',
         action: 'VERSION_SAVE_FILE',
+        eventType: 'VERSION_SAVE_FILE',
         resourceType: 'version_project',
         resourceId: projectId,
         metadata: {

--- a/researchflow-production-main/services/orchestrator/src/routes/visualization.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/visualization.ts
@@ -315,6 +315,7 @@ router.post(
       await logAction({
         userId: req.user?.id || 'anonymous',
         action: 'CHART_GENERATED',
+        eventType: 'CHART_GENERATED',
         resourceType: 'visualization',
         resourceId: visualizationResult.figure_id || requestId,
         metadata: {
@@ -678,6 +679,7 @@ router.delete(
       await logAction({
         userId: req.user?.id || 'anonymous',
         action: 'FIGURE_DELETED',
+        eventType: 'FIGURE_DELETED',
         resourceType: 'figure',
         resourceId: id,
         metadata: { deleted_at: new Date().toISOString() },
@@ -798,6 +800,7 @@ router.patch(
       await logAction({
         userId: req.user?.id || 'anonymous',
         action: 'PHI_SCAN_UPDATED',
+        eventType: 'PHI_SCAN_UPDATED',
         resourceType: 'figure',
         resourceId: id,
         metadata: {

--- a/researchflow-production-main/services/orchestrator/src/services/analytics.service.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/analytics.service.ts
@@ -176,6 +176,7 @@ export async function trackEvent(event: AnalyticsEventInput): Promise<boolean> {
     // Log PHI detection (without the actual values)
     await logAction({
       action: 'ANALYTICS_PHI_REDACTED',
+      eventType: 'ANALYTICS_PHI_REDACTED',
       userId: event.userId,
       details: {
         eventName: event.eventName,

--- a/researchflow-production-main/services/orchestrator/src/services/feature-flags.service.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/feature-flags.service.ts
@@ -280,6 +280,7 @@ export async function setFlag(
   // Write audit log
   await logAction({
     action: 'FEATURE_FLAG_CHANGED',
+    eventType: 'FEATURE_FLAG_CHANGED',
     userId: actorUserId,
     resourceId: key,
     resourceType: 'feature_flag',
@@ -324,6 +325,7 @@ export async function deleteFlag(key: string, actorUserId: string): Promise<void
   // Write audit log
   await logAction({
     action: 'FEATURE_FLAG_DELETED',
+    eventType: 'FEATURE_FLAG_DELETED',
     userId: actorUserId,
     resourceId: key,
     resourceType: 'feature_flag',


### PR DESCRIPTION
SCOPE CONTRACT (verbatim)
Root cause: TS2345 logAction calls are missing required eventType.
Files in scope:
services/orchestrator/src/middleware/visualization-error-handler.ts
services/orchestrator/src/routes/ai-extraction.ts
services/orchestrator/src/routes/analysis-execution.ts
services/orchestrator/src/routes/export-ris.ts
services/orchestrator/src/routes/integrations-storage.ts
services/orchestrator/src/routes/mesh-lookup.ts
services/orchestrator/src/routes/version-control.ts
services/orchestrator/src/routes/visualization.ts
services/orchestrator/src/services/analytics.service.ts
services/orchestrator/src/services/feature-flags.service.ts
Fix pattern: Add eventType to each logAction object literal using local context (prefer existing action or nearby constants); no other edits.
Safety classification: Behavior-preserving.
Forbidden changes: No audit-service.ts changes; no schema/migrations; no refactors; no suppressions.
Expected error delta range + measurement: Decrease by 0–16 TS2345 errors (target 16 if all sites are addressed), measured by pnpm -C researchflow-production-main run typecheck and comparing total errors vs the post-PR95 baseline of 871 errors across 204 files.
Exclusions: Any file requiring semantic guessing or behavior change is out of scope.

Canonical metrics
Before baseline (post-PR95): 871 errors / 204 files
After: 855 errors / 201 files

TS2345 logAction missing eventType: eliminated in these files
- services/orchestrator/src/middleware/visualization-error-handler.ts
- services/orchestrator/src/routes/ai-extraction.ts
- services/orchestrator/src/routes/analysis-execution.ts
- services/orchestrator/src/routes/export-ris.ts
- services/orchestrator/src/routes/integrations-storage.ts
- services/orchestrator/src/routes/mesh-lookup.ts
- services/orchestrator/src/routes/version-control.ts
- services/orchestrator/src/routes/visualization.ts
- services/orchestrator/src/services/analytics.service.ts
- services/orchestrator/src/services/feature-flags.service.ts

Changed file list matches contract exactly: YES

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F96&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->