### PR TITLE
PR97: Fix citation-manager TS2345 style/authors args

### DIFF
--- a/researchflow-production-main/packages/manuscript-engine/src/services/citation-manager.service.ts
+++ b/researchflow-production-main/packages/manuscript-engine/src/services/citation-manager.service.ts
@@ -31,7 +31,7 @@ export class CitationManagerService {
     const fullCitation: Citation = {
       ...citation,
       id,
-      formatted: this.formatCitation(citation as Citation, 'AMA'),
+      formatted: this.formatCitation(citation as Citation, 'superscript_number'),
     };
 
     this.citations.set(id, fullCitation);
@@ -103,7 +103,9 @@ export class CitationManagerService {
    * Format in AMA style
    */
   private formatAMA(citation: Citation): string {
-    const authors = this.formatAuthorsAMA(citation.authors);
+    const authors = this.formatAuthorsAMA(
+      citation.authors.map((author) => author.lastName ?? author.initials ?? author.firstName ?? 'Unknown'),
+    );
     let formatted = `${authors}. ${citation.title}.`;
 
     if (citation.journal) {
@@ -137,7 +139,9 @@ export class CitationManagerService {
    * Format in APA style
    */
   private formatAPA(citation: Citation): string {
-    const authors = this.formatAuthorsAPA(citation.authors);
+    const authors = this.formatAuthorsAPA(
+      citation.authors.map((author) => author.lastName ?? author.initials ?? author.firstName ?? 'Unknown'),
+    );
     let formatted = `${authors} (${citation.year}). ${citation.title}.`;
 
     if (citation.journal) {
@@ -165,7 +169,9 @@ export class CitationManagerService {
    * Format in Vancouver style
    */
   private formatVancouver(citation: Citation): string {
-    const authors = this.formatAuthorsVancouver(citation.authors);
+    const authors = this.formatAuthorsVancouver(
+      citation.authors.map((author) => author.lastName ?? author.initials ?? author.firstName ?? 'Unknown'),
+    );
     let formatted = `${authors}. ${citation.title}.`;
 
     if (citation.journal) {
@@ -202,7 +208,9 @@ export class CitationManagerService {
    * Format in Chicago style
    */
   private formatChicago(citation: Citation): string {
-    const authors = this.formatAuthorsChicago(citation.authors);
+    const authors = this.formatAuthorsChicago(
+      citation.authors.map((author) => author.lastName ?? author.initials ?? author.firstName ?? 'Unknown'),
+    );
     let formatted = `${authors}. "${citation.title}."`;
 
     if (citation.journal) {


### PR DESCRIPTION
SCOPE CONTRACT (PR97)

Root cause (single cluster): TS2345 in citation-manager.service.ts where citation-style and author-list argument types no longer match formatter API (unsupported "AMA" literal; author objects array passed where string[] expected).
Files in scope (explicit list):
packages/manuscript-engine/src/services/citation-manager.service.ts
Fix pattern (mechanical rules):
Replace "AMA" with "superscript_number" at the failing call site(s) unless local code explicitly indicates a different supported style.
Convert { firstName?/lastName?/initials? }[] to string[] inline at each failing call site using: lastName ?? initials ?? firstName ?? "Unknown".
Do not change any other arguments, control flow, or structure.
Safety classification: behavior-preserving (types-only).
Forbidden changes (explicit list):
No edits outside citation-manager.service.ts.
No refactors (no new helpers, signature changes, renames, moves).
No suppressions or type-widening (as any, @ts-ignore, eslint disables, etc.).
No formatting-only churn.
No behavior changes beyond the explicit style mapping and deterministic author conversion.
Expected error delta range + canonical measurement method:
Expected improvement: -5 TS2345 errors (range: -5 to -5), limited to the five call sites in this file.
Canonical measurement:
pnpm -C researchflow-production-main run typecheck 2>&1 | tee typecheck.out
Total errors: grep -oE 'error TS[0-9]+' typecheck.out | wc -l
Files with ≥1 TS error:
grep -oE '^[^[:space:]]+\([0-9]+,[0-9]+\): error TS' typecheck.out | sed -E 's/\([0-9]+,[0-9]+\): error TS.*$//' | sort -u | wc -l
Verify elimination of:
citation-manager.service.ts(34,60)
citation-manager.service.ts(106,43)
citation-manager.service.ts(140,43)
citation-manager.service.ts(168,49)
citation-manager.service.ts(205,47)
Exclusion rule:
If a fix requires guessing citation semantics beyond the "AMA" → "superscript_number" mapping or requires broader refactoring, exclude it from scope and report it.

Canonical before/after metrics (errors + files)
Before: errors=855, files=201
After: errors=850, files=201

Verification
- The 5 specified TS2345 sites are eliminated.
- Only in-scope file changed: packages/manuscript-engine/src/services/citation-manager.service.ts

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F97&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->