### PR TITLE
PR98: Use drizzleCompat for ilike/isNull imports

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/routes/analytics.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/analytics.ts
@@ -9,7 +9,8 @@
  */
 
 import { userConsents } from '@researchflow/core/schema';
-import { eq, and, isNull } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
+import { isNull } from "../db/drizzleCompat";
 import { Router, type Request, type Response } from 'express';
 
 import { db } from '../../db';

--- a/researchflow-production-main/services/orchestrator/src/routes/consent.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/consent.ts
@@ -10,7 +10,8 @@
  */
 
 import { userConsents, auditLogs } from '@researchflow/core/schema';
-import { eq, and, desc, isNull } from 'drizzle-orm';
+import { eq, and, desc } from 'drizzle-orm';
+import { isNull } from "../db/drizzleCompat";
 import { Router, type Request, type Response } from 'express';
 
 import { db } from '../../db';

--- a/researchflow-production-main/services/orchestrator/src/routes/papers.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/papers.ts
@@ -32,7 +32,8 @@ import { createHash } from 'crypto';
 import fs from 'fs/promises';
 import path from 'path';
 
-import { sql, eq, desc, and, ilike, or } from 'drizzle-orm';
+import { sql, eq, desc, and, or } from 'drizzle-orm';
+import { ilike } from "../db/drizzleCompat";
 import { Router, Request, Response } from 'express';
 import multer from 'multer';
 import { nanoid } from 'nanoid';

--- a/researchflow-production-main/services/orchestrator/src/routes/source-attributes.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/source-attributes.ts
@@ -10,7 +10,8 @@
  * @version 1.0.0
  */
 
-import { desc, eq, and, sql, gte, lte, isNull } from 'drizzle-orm';
+import { desc, eq, and, sql, gte, lte } from 'drizzle-orm';
+import { isNull } from "../db/drizzleCompat";
 import { Router, Request, Response, NextFunction } from 'express';
 import * as z from 'zod';
 

--- a/researchflow-production-main/services/orchestrator/src/services/artifactGraphService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/artifactGraphService.ts
@@ -7,7 +7,8 @@
  * - Detecting outdated nodes
  */
 import { artifactEdges, artifacts, artifactVersions } from "@researchflow/core/schema";
-import { eq, and, isNull, sql, desc } from "drizzle-orm";
+import { eq, and, sql, desc } from "drizzle-orm";
+import { isNull } from "../db/drizzleCompat";
 import { nanoid } from "nanoid";
 
 import { db } from "../../db";

--- a/researchflow-production-main/services/orchestrator/src/services/claimsService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/claimsService.ts
@@ -10,7 +10,8 @@ import { createHash } from "crypto";
 
 import { claims, claimEvidenceLinks, artifacts } from "@researchflow/core/schema";
 import { scan as scanPhi, hasPhi } from "@researchflow/phi-engine";
-import { eq, and, isNull, desc, sql } from "drizzle-orm";
+import { eq, and, desc, sql } from "drizzle-orm";
+import { isNull } from "../db/drizzleCompat";
 import { nanoid } from "nanoid";
 
 import { db } from "../../db";

--- a/researchflow-production-main/services/orchestrator/src/services/commentService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/commentService.ts
@@ -11,7 +11,8 @@ import { createHash } from "crypto";
 
 import { comments, artifacts, artifactVersions } from "@researchflow/core/schema";
 import { scan as scanPhi, hasPhi } from "@researchflow/phi-engine";
-import { eq, and, isNull, desc, sql } from "drizzle-orm";
+import { eq, and, desc, sql } from "drizzle-orm";
+import { isNull } from "../db/drizzleCompat";
 import { nanoid } from "nanoid";
 
 import { db } from "../../db";

--- a/researchflow-production-main/services/orchestrator/src/services/datasets-persistence.service.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/datasets-persistence.service.ts
@@ -7,7 +7,8 @@
 
 import { datasets } from '@researchflow/core/schema';
 import { DatasetMetadata } from '@researchflow/core/types/classification';
-import { eq, ilike, and, sql } from 'drizzle-orm';
+import { eq, and, sql } from 'drizzle-orm';
+import { ilike } from "../db/drizzleCompat";
 
 import { db } from '../../db';
 

--- a/researchflow-production-main/services/orchestrator/src/services/embeddingService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/embeddingService.ts
@@ -8,7 +8,8 @@
 import crypto from 'crypto';
 
 import { artifacts, artifactEmbeddings } from '@researchflow/core/schema';
-import { eq, and, isNull } from 'drizzle-orm';
+import { eq, and } from 'drizzle-orm';
+import { isNull } from "../db/drizzleCompat";
 
 import { db } from '../../db';
 


### PR DESCRIPTION
SCOPE CONTRACT (PR98 — corrected)

Root cause: TS2305 because ilike/isNull are not exported by current drizzle-orm types, while local compat shim exists in drizzleCompat.ts.
In scope (Option A): Import-only changes to use compat shim for ilike/isNull and remove them from drizzle-orm imports; no usage-site changes.
Files in scope:
- researchflow-production-main/services/orchestrator/src/services/artifactGraphService.ts
- researchflow-production-main/services/orchestrator/src/services/commentService.ts
- researchflow-production-main/services/orchestrator/src/services/claimsService.ts
- researchflow-production-main/services/orchestrator/src/services/embeddingService.ts
- researchflow-production-main/services/orchestrator/src/services/datasets-persistence.service.ts
- researchflow-production-main/services/orchestrator/src/routes/consent.ts
- researchflow-production-main/services/orchestrator/src/routes/analytics.ts
- researchflow-production-main/services/orchestrator/src/routes/source-attributes.ts
- researchflow-production-main/services/orchestrator/src/routes/papers.ts
Out of scope: Any changes to count() (imports or usage) and any non-import refactors; defer count issues to PR99 unless import-only fix is proven elsewhere in-repo.
Non-goals: No runtime/query logic changes, no code formatting, no unrelated TypeScript fixes.

Canonical metrics
- Before: 851 errors, 202 files
- After: 841 errors, 200 files

TS2305 ilike/isNull
- Eliminated in scoped files.

Changed files (matches 9-file contract)
- researchflow-production-main/services/orchestrator/src/services/artifactGraphService.ts
- researchflow-production-main/services/orchestrator/src/services/commentService.ts
- researchflow-production-main/services/orchestrator/src/services/claimsService.ts
- researchflow-production-main/services/orchestrator/src/services/embeddingService.ts
- researchflow-production-main/services/orchestrator/src/services/datasets-persistence.service.ts
- researchflow-production-main/services/orchestrator/src/routes/consent.ts
- researchflow-production-main/services/orchestrator/src/routes/analytics.ts
- researchflow-production-main/services/orchestrator/src/routes/source-attributes.ts
- researchflow-production-main/services/orchestrator/src/routes/papers.ts

No changes to count() imports/usages; deferred to PR99.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F98&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->