### PR TITLE
Fix cursor integration export conflicts

### DIFF
--- a/researchflow-production-main/packages/cursor-integration/src/index.ts
+++ b/researchflow-production-main/packages/cursor-integration/src/index.ts
@@ -326,5 +326,3 @@ All commands accept optional JSON parameters for customization:
 - \`context\`: Additional context string
 - Command-specific params (see examples above)
 `;
-
-export { AgentCommand, CursorConfig };


### PR DESCRIPTION
## Summary\n- remove duplicate re-export of AgentCommand and CursorConfig in cursor-integration index\n\n## Testing\n- pnpm -C researchflow-production-main run typecheck

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F99&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->