### PR TITLE
PR100 — TS2484 ai-router custom exports

### DIFF
--- a/researchflow-production-main/packages/ai-router/src/dispatchers/custom.ts
+++ b/researchflow-production-main/packages/ai-router/src/dispatchers/custom.ts
@@ -601,9 +601,3 @@ export function createCustomDispatcher(config?: {
 }): CustomDispatcher {
   return new CustomDispatcher(config);
 }
-
-export type {
-  CustomAgentRegistry,
-  DispatchDecision,
-  CustomDispatchContext,
-};


### PR DESCRIPTION
## Summary
- Dedupe redundant export declarations for CustomAgentRegistry, DispatchDecision, and CustomDispatchContext in custom dispatcher

## Scope
- packages/ai-router/src/dispatchers/custom.ts

## Verification
- pnpm -C researchflow-production-main run typecheck 2>&1 | tee typecheck.out
- grep -n 'error TS2484: Export declaration conflicts' typecheck.out

## Metrics
- Before: 851 TS errors across 202 files (typecheck-before.out)
- After: 832 TS errors across 199 files (typecheck.out)
- TS2484 conflicts now: 3 remaining (none in custom.ts)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F100&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->