### PR TITLE
Fix duplicate exports causing TS2484

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/langchain-bridge.ts
+++ b/researchflow-production-main/services/orchestrator/src/langchain-bridge.ts
@@ -872,7 +872,5 @@ export function resetLangChainBridge(): void {
 // ============================================================================
 
 export {
-  LangChainBridge,
   LangChainCircuitBreaker,
-  RetryOptions,
 };

--- a/researchflow-production-main/services/orchestrator/src/middleware/visualization-error-handler.ts
+++ b/researchflow-production-main/services/orchestrator/src/middleware/visualization-error-handler.ts
@@ -580,5 +580,3 @@ export const validateVisualizationRequest = (req: Request, res: Response, next: 
     VisualizationErrorHandler.handleVisualizationError(error, req, res, next);
   }
 };
-
-export { VisualizationErrorHandler };


### PR DESCRIPTION
Removes redundant re-exports of already-exported symbols to resolve TS2484 export declaration conflicts.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F101&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->