### PR TITLE
Fix OpenAI namespace type usage

### DIFF
--- a/researchflow-production-main/packages/ai-router/src/model-router.service.ts
+++ b/researchflow-production-main/packages/ai-router/src/model-router.service.ts
@@ -8,6 +8,7 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 import OpenAI from 'openai';
+import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions';
 
 import {
   getConfig,
@@ -635,7 +636,7 @@ export class ModelRouterService {
 
     const startTime = Date.now();
 
-    const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [];
+    const messages: ChatCompletionMessageParam[] = [];
 
     if (request.systemPrompt) {
       messages.push({

--- a/researchflow-production-main/packages/ai-router/src/providers/openai.ts
+++ b/researchflow-production-main/packages/ai-router/src/providers/openai.ts
@@ -10,6 +10,7 @@ import type {
   ChatCompletionCreateParams,
   ChatCompletionMessageParam,
   ChatCompletion,
+  ChatCompletionChunk,
 } from 'openai/resources/chat/completions';
 
 import { logAIUsage, type AIUsageLogEntry } from '../notion/notionLogger';
@@ -182,7 +183,7 @@ export class OpenAIProvider {
   async *streamChatCompletion(
     params: Omit<ChatCompletionCreateParams, 'model' | 'stream'> & { model?: string },
     options: OpenAIRequestOptions = {}
-  ): AsyncGenerator<OpenAI.Chat.Completions.ChatCompletionChunk, OpenAIResponse, unknown> {
+  ): AsyncGenerator<ChatCompletionChunk, OpenAIResponse, unknown> {
     const model = params.model ?? this.defaultModel;
     const startTime = Date.now();
     let inputTokens = 0;


### PR DESCRIPTION
## Summary
- replace OpenAI namespace type references with explicit imported types
- keep runtime OpenAI client calls unchanged

## Testing
- pnpm -C researchflow-production-main run typecheck 2>&1 | tee typecheck.out

## Canonical gate evidence
### origin/main
- total errors: 829
- files with ≥1 TS error: 198
- TS2702 lines:
  - packages/ai-router/src/model-router.service.ts(638,21)
  - packages/ai-router/src/providers/claude.ts(172,21)
  - packages/ai-router/src/providers/openai.ts(185,21)
  - services/orchestrator/src/services/paper-copilot.service.ts(365,21)

### PR branch (pr-ts2702-openai)
- total errors: 827
- files with ≥1 TS error: 196
- TS2702 lines:
  - packages/ai-router/src/providers/claude.ts(172,21)
  - services/orchestrator/src/services/paper-copilot.service.ts(365,21)
