### PR TITLE
fix(ts): remove AIUsageLogEntry tool field (mercury-coder)

### DIFF
--- a/researchflow-production-main/packages/ai-router/src/providers/mercury-coder.ts
+++ b/researchflow-production-main/packages/ai-router/src/providers/mercury-coder.ts
@@ -783,7 +783,6 @@ ${codeToEdit}
   ): Promise<void> {
     try {
       const logEntry: AIUsageLogEntry = {
-        tool: 'mercury-coder',
         provider: 'inception-labs',
         model: result.model,
         taskType: (options?.taskType as AITaskType) ?? 'code',


### PR DESCRIPTION
## Canonical Typecheck Evidence
Command: pnpm -C researchflow-production-main run typecheck

Before (origin/main):
- Total TS errors: 826
- Files w/ ≥1 TS error: 195
- TS2353 mention (tool): packages/ai-router/src/providers/mercury-coder.ts(786,9): error TS2353: Object literal may only specify known properties, and 'tool' does not exist in type 'AIUsageLogEntry'.

After (this PR):
- Total TS errors: 826
- Files w/ ≥1 TS error: 195
- TS2353 mention (tool): 0

Scope confirmation:
- Changed files (exact): packages/ai-router/src/providers/mercury-coder.ts
- Runtime behavior changes: NONE
- Suppressions/refactors/formatting: NONE

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F106&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->