### PR TITLE
fix(ts): add AIUsageLogEntry status field (mercury-coder)

### DIFF
--- a/researchflow-production-main/packages/ai-router/src/providers/mercury-coder.ts
+++ b/researchflow-production-main/packages/ai-router/src/providers/mercury-coder.ts
@@ -791,6 +791,7 @@ ${codeToEdit}
         totalTokens: result.usage.totalTokens,
         latencyMs: result.metrics.latencyMs,
         estimatedCostUsd: result.usage.estimatedCostUsd,
+        status: 'success',
         researchId: options?.researchId,
         userId: options?.userId,
         sessionId: options?.sessionId,


### PR DESCRIPTION
## Canonical Typecheck Evidence
Command: pnpm -C researchflow-production-main run typecheck

Before (origin/main):
- Total TS errors: 825
- Files w/ ≥1 TS error: 194
- Targeted TS2741 line: packages/ai-router/src/providers/mercury-coder.ts(785,13): error TS2741: Property 'status' is missing in type '{ provider: string; model: string; taskType: string; inputTokens: number; outputTokens: number; totalTokens: number; latencyMs: number; estimatedCostUsd: number; researchId: string; userId: string; sessionId: string; agentId: string; metadata: { ...; }; }' but required in type 'AIUsageLogEntry'.

After (this PR):
- Total TS errors: 824
- Files w/ ≥1 TS error: 193
- Targeted TS2741 line: 0

Scope confirmation:
- Changed files (exact): packages/ai-router/src/providers/mercury-coder.ts
- Runtime behavior changes: NONE
- Suppressions/refactors/formatting: NONE

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F108&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->