### PR TITLE
fix(ci): run lint/typecheck/tests from researchflow-production-main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
   lint-typecheck-test:
     name: Lint, typecheck & test
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: researchflow-production-main
     services:
       postgres:
         image: postgres:16-alpine
@@ -65,7 +68,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('researchflow-production-main/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
@@ -83,7 +86,7 @@ jobs:
         continue-on-error: true
 
       - name: Apply orchestrator DB migrations in order
-        run: node researchflow-production-main/services/orchestrator/scripts/ci-migrate.mjs
+        run: node services/orchestrator/scripts/ci-migrate.mjs
         env:
           DATABASE_URL: postgresql://researchflow_test:test_password@localhost:5432/researchflow_test
 


### PR DESCRIPTION
Added job-level defaults.run.working-directory: researchflow-production-main

Updated pnpm cache key to hash researchflow-production-main/pnpm-lock.yaml

Normalized migration step path to be relative to the new working directory

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F117&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->