### PR TITLE
fix(db): enable pgcrypto for orchestrator migrations

### DIFF
--- a/researchflow-production-main/services/orchestrator/migrations/001_artifacts_and_graph.sql
+++ b/researchflow-production-main/services/orchestrator/migrations/001_artifacts_and_graph.sql
@@ -3,6 +3,7 @@
 -- Description: Establishes foundation for artifact provenance tracking
 
 BEGIN;
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 
 -- ============================================================
 -- Core artifacts table


### PR DESCRIPTION
## Summary
- Enable pgcrypto in the first orchestrator migration so gen_random_uuid() works on fresh databases.

## Why CI needs this
- CI spins up a fresh Postgres service and migration 001 uses DEFAULT gen_random_uuid(), which requires pgcrypto to be enabled.

## Scope
- Changed: researchflow-production-main/services/orchestrator/migrations/001_artifacts_and_graph.sql

## Validation
- pnpm -C researchflow-production-main install --frozen-lockfile
  - Done in 4s
- DATABASE_URL=postgresql://ros:postgres@host.docker.internal:5432/ros node services/orchestrator/scripts/ci-migrate.mjs (via docker node image with psql)
  - Migration 001 applied successfully; run stopped at migration 014 with missing gin_trgm_ops

## Risk
- Low: adds pgcrypto extension creation at migration start; no schema changes beyond extension enablement.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F120&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->