### PR TITLE
fix(db): enable pg_trgm for trigram indexes

### DIFF
--- a/researchflow-production-main/services/orchestrator/migrations/014_guidelines_engine.sql
+++ b/researchflow-production-main/services/orchestrator/migrations/014_guidelines_engine.sql
@@ -2,6 +2,8 @@
 -- Migration: 014_guidelines_engine.sql
 -- Purpose: Create tables for clinical guidelines, scoring systems, and validation blueprints
 
+CREATE EXTENSION IF NOT EXISTS "pg_trgm";
+
 -- Source Registry: tracks where guidelines come from and licensing
 CREATE TABLE IF NOT EXISTS source_registry (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),


### PR DESCRIPTION
## Summary
- Enable pg_trgm in migration 014 so gin_trgm_ops indexes work on fresh databases (CI).
## Scope
- Changed: researchflow-production-main/services/orchestrator/migrations/014_guidelines_engine.sql
## Validation
- pnpm -C researchflow-production-main install --frozen-lockfile (ok)
- DATABASE_URL=postgresql://researchflow_test:test_password@localhost:5432/researchflow_test node researchflow-production-main/services/orchestrator/scripts/ci-migrate.mjs (failed: Applying migration: 001_artifacts_and_graph.sql; ci-migrate: Failed applying 001_artifacts_and_graph.sql)
## Risk
- Low: adds extension enablement only; no schema changes beyond pg_trgm availability.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F121&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->