### PR TITLE
chore(ci): add install hints when psql is missing

### DIFF
--- a/researchflow-production-main/services/orchestrator/scripts/ci-migrate.mjs
+++ b/researchflow-production-main/services/orchestrator/scripts/ci-migrate.mjs
@@ -54,6 +54,14 @@ for (const name of files) {
     console.error('ci-migrate: Failed to execute psql (spawn error):', result.error.message);
     if (result.error.code === 'ENOENT') {
       console.error('psql not found on PATH');
+      console.error('');
+      console.error('Install psql:');
+      console.error('  Ubuntu/Debian (CI/local):');
+      console.error('    sudo apt-get update && sudo apt-get install -y postgresql-client');
+      console.error('  macOS (Homebrew):');
+      console.error('    brew install libpq');
+      console.error('    echo \'export PATH="$(brew --prefix libpq)/bin:$PATH"\' >> ~/.zshrc');
+      console.error('    (then open a new shell)');
     }
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- Make ci-migrate ENOENT failures self-serve by printing install hints for psql.

## Scope
- Changed: researchflow-production-main/services/orchestrator/scripts/ci-migrate.mjs

## Validation
- PATH=/nonexistent DATABASE_URL=... node .../ci-migrate.mjs
  - Output includes install hints

## Risk
- None: logging-only.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F124&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->