### PR TITLE
fix(db): add users table migration for orchestrator

### DIFF
--- a/researchflow-production-main/services/orchestrator/migrations/000_users.sql
+++ b/researchflow-production-main/services/orchestrator/migrations/000_users.sql
@@ -1,0 +1,14 @@
+-- Migration: Create users table
+-- This migration must run first to ensure the users table exists
+-- before other migrations that reference it via foreign keys.
+
+-- Ensure pgcrypto extension is available for UUID generation
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- Create minimal users table
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email VARCHAR(255) UNIQUE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- Add an early orchestrator migration to create the users table required by 015_transparency_compliance.sql and other FK references.

## Scope
- Added: researchflow-production-main/services/orchestrator/migrations/000_users.sql

## Validation
- CI-parity docker migration run; migrations pass through 015_transparency_compliance.sql.

## Risk
- Low: adds a minimal users table and required extension; does not modify existing schema/migrations.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F125&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->