### PR TITLE
fix(ts): use default OpenAI import in embedder.ts (TS2614)

### DIFF
--- a/researchflow-production-main/packages/vector-store/src/embedder.ts
+++ b/researchflow-production-main/packages/vector-store/src/embedder.ts
@@ -4,7 +4,7 @@
  * @package @researchflow/vector-store
  */
 
-import { OpenAI } from 'openai';
+import OpenAI from 'openai';
 
 import type { EmbeddingConfig, ChunkConfig, DEFAULT_CHUNK_CONFIG, DEFAULT_EMBEDDING_CONFIG } from './types.js';
 


### PR DESCRIPTION
## Summary
- Mechanical TS2614 fix: changed OpenAI import from named to default per compiler suggestion in one file.

## Scope
- ✅ `packages/vector-store/src/embedder.ts` only
- ❌ No runtime changes, no refactors, no deps/tsconfig, no suppressions

## Typecheck (canonical)
Command:
```bash
cd researchflow-production-main && pnpm run typecheck 2>&1 | tee typecheck.out
```

### Before
- Total errors: 816
- Files with ≥1 error: 189
- Targeted line:
```txt
packages/vector-store/src/embedder.ts(7,10): error TS2614: Module '"openai"' has no exported member 'OpenAI'. Did you mean to use 'import OpenAI from "openai"' instead?
```

### After
- Total errors: **815** (↓1)
- Files with ≥1 error: **189** (unchanged)
- Targeted line gone: ✅
```bash
$ grep -n "error TS2614" typecheck.out | grep "embedder.ts"
(no output - error eliminated)
```

### Top error codes (after)
```
 311 TS2345
 186 TS2305
 126 TS2339
  61 TS2322
  20 TS2724
  15 TS2307
  10 TS2554
  10 TS2538
   9 TS2558
   8 TS2614  ← (was 9)
```

## Files changed
- `packages/vector-store/src/embedder.ts`

## Change
```diff
- import { OpenAI } from 'openai';
+ import OpenAI from 'openai';
```

---

**Pattern:** Follows same approach as PR #130 (express-rate-limit fix)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F131&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->