### PR TITLE
fix(ts): align pluginMarketplaceService test audit log import (TS2614)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/services/__tests__/pluginMarketplaceService.test.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/__tests__/pluginMarketplaceService.test.ts
@@ -13,7 +13,7 @@ import {
   enablePlugin,
   disablePlugin,
   getInstallation,
-  getAuditLog,
+  getPluginAuditLog,
 } from '../pluginMarketplaceService';
 
 describe('PluginMarketplaceService', () => {
@@ -126,12 +126,12 @@ describe('PluginMarketplaceService', () => {
     });
   });
 
-  describe('getAuditLog', () => {
+  describe('getPluginAuditLog', () => {
     it('should record installation actions', () => {
       const plugins = listPlugins();
       installPlugin(plugins[0].id, `audit-${tenantId}`, userId);
 
-      const logs = getAuditLog({ tenantId: `audit-${tenantId}` });
+      const logs = getPluginAuditLog({ tenantId: `audit-${tenantId}` });
       expect(logs.length).toBeGreaterThan(0);
       expect(logs.some(l => l.action === 'INSTALL')).toBe(true);
     });
@@ -140,7 +140,7 @@ describe('PluginMarketplaceService', () => {
       const plugins = listPlugins();
       installPlugin(plugins[0].id, `filter-${tenantId}`, userId);
 
-      const logs = getAuditLog({ pluginId: plugins[0].id });
+      const logs = getPluginAuditLog({ pluginId: plugins[0].id });
       expect(logs.every(l => l.pluginId === plugins[0].id)).toBe(true);
     });
   });


### PR DESCRIPTION
## Summary
Tests-only: rename getAuditLog import/calls to getPluginAuditLog to match service exports.

## Root Cause
Test imports a non-existent named export getAuditLog from pluginMarketplaceService.
Service exports getPluginAuditLog instead.
Error: TS2614 - Module has no exported member (with import suggestion)

## Scope
- services/orchestrator/src/services/__tests__/pluginMarketplaceService.test.ts only
- No runtime changes, no deps/tsconfig, no suppressions

## Typecheck Results

### Before
- Total TS2614 errors: 8
- Targeted error at line 16:
```
error TS2614: Module '"../pluginMarketplaceService"' has no exported member 'getAuditLog'. 
Did you mean to use 'import getAuditLog from "../pluginMarketplaceService"' instead?
```

### After
- Total TS2614 errors: 7 (reduced by 1)
- Targeted line eliminated (verified: grep returns no output)

### Top error codes after fix
```
 311 TS2345
 186 TS2305
 126 TS2339
  61 TS2322
  20 TS2724
  15 TS2307
  10 TS2554
  10 TS2538
   9 TS2558
   8 TS2353
```

Note: TS2614 no longer in top 10 after this fix brings it down to 7 occurrences.

## Changes Made
1. Import: getAuditLog → getPluginAuditLog (line 14)
2. Describe block: 'getAuditLog' → 'getPluginAuditLog' (line 134)
3. Call sites: getAuditLog(...) → getPluginAuditLog(...) (lines 138, 146)

## Validation
- TS2614 error eliminated
- No new errors introduced
- Tests-only scope maintained
