### PR TITLE
fix(ts): remove invalid AxiosInstance import in ai-bridge connection pool (TS2614)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/middleware/ai-bridge-connection-pool.ts
+++ b/researchflow-production-main/services/orchestrator/src/middleware/ai-bridge-connection-pool.ts
@@ -7,9 +7,11 @@
 import http from 'http';
 import https from 'https';
 
-import axios, { AxiosInstance } from 'axios';
+import axios from 'axios';
 
 import { createLogger } from '../utils/logger';
+
+type AxiosClient = ReturnType<typeof axios.create>;
 
 const logger = createLogger('ai-bridge-pool');
 
@@ -32,7 +34,7 @@ interface PooledRequest {
 }
 
 class AIBridgeConnectionPool {
-  private client: AxiosInstance;
+  private client: AxiosClient;
   private requestQueue: PooledRequest[] = [];
   private activeRequests = 0;
   private config: ConnectionPoolConfig;


### PR DESCRIPTION
## Summary

Fixes TS2614 error in ai-bridge-connection-pool.ts by replacing the invalid named import of `AxiosInstance` from axios with a derived type pattern.

## Root Cause

The axios package does not export `AxiosInstance` as a named export under current typings/module resolution, causing TypeScript error TS2614.

## Solution

- Removed named import: `{ AxiosInstance }`
- Added derived type: `type AxiosClient = ReturnType<typeof axios.create>`
- Updated field declaration: `private client: AxiosClient`

This approach derives the type from the return value of `axios.create()` without relying on a potentially unavailable named export.

## Impact

**Before:**
- Total errors: 814
- Files with ≥1 error: 787

**After:**
- Total errors: 813
- Files with ≥1 error: 786

**Net change:** -1 total errors, -1 files-with-errors

## Verification

TS2614 in ai-bridge-connection-pool.ts: ✓ ELIMINATED

```bash
grep -n "error TS2614" typecheck.out | grep "ai-bridge-connection-pool.ts"
# No output (error is gone)
```

## Top 10 TS Error Codes (After Fix)

1. TS2345: 311 occurrences
2. TS2305: 186 occurrences
3. TS2339: 126 occurrences
4. TS2322: 61 occurrences
5. TS2724: 20 occurrences
6. TS2307: 15 occurrences
7. TS2554: 10 occurrences
8. TS2538: 10 occurrences
9. TS2558: 9 occurrences
10. TS2353: 8 occurrences

## Changes

- `services/orchestrator/src/middleware/ai-bridge-connection-pool.ts` (types-only)

## Testing

✓ TypeScript compilation verification
✓ No runtime logic changes
✓ No compensating errors introduced

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F135&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->