### PR TITLE
fix(ts): remove invalid axios named imports in guidelines proxy routes (TS2614)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/routes/guidelines-proxy.routes.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/guidelines-proxy.routes.ts
@@ -6,8 +6,11 @@
  * the Node.js orchestrator for better maintainability.
  */
 
-import axios, { AxiosError, AxiosRequestConfig } from 'axios';
+import axios from 'axios';
 import { Router, Request, Response, NextFunction } from 'express';
+
+// Type alias for axios request config (avoids TS2614 on named import)
+type AxiosRequestConfig = Parameters<typeof axios.request>[0];
 
 const router = Router();
 
@@ -48,7 +51,7 @@ async function proxyRequest(
     const response = await engineClient.request(config);
     res.status(response.status).json(response.data);
   } catch (error) {
-    const axiosError = error as AxiosError;
+    const axiosError = error as axios.AxiosError;
     if (axiosError.response) {
       // Forward error response from engine
       res.status(axiosError.response.status).json(axiosError.response.data);


### PR DESCRIPTION
## Overview
Clean fix for TS2614 errors in guidelines-proxy.routes.ts.

**Scope**: ONE file, ONE commit (fixes PR136 scope breach).

## Root Cause  
TS2614 when importing AxiosError and AxiosRequestConfig as named exports from axios (not exported as named members).

## Changes
File: services/orchestrator/src/routes/guidelines-proxy.routes.ts (ONLY)

1. Removed invalid named imports
2. Added type alias: type AxiosRequestConfig = Parameters<typeof axios.request>[0]
3. Use axios.AxiosError for type casting

## Impact
- Expected: -2 TS2614 errors
- Files changed: 1
- Commits: 1

## Validation
```bash
pnpm run typecheck | grep guidelines-proxy.routes.ts
# Expected: no TS2614 errors
```

## Note
Replaces PR136 (closed due to scope breach - included ai-bridge-connection-pool.ts).

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F137&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->