### PR TITLE
fix(ts): bypass core package export resolution in app-mode invariants test (TS2305)

### DIFF
--- a/researchflow-production-main/tests/governance/app-mode-invariants.test.ts
+++ b/researchflow-production-main/tests/governance/app-mode-invariants.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-import { AppMode, MODE_CONFIGS } from '@researchflow/core';
+import { AppMode, MODE_CONFIGS } from '../../packages/core/types/governance';
 
 describe('App Mode Type Definitions', () => {
   it('should define exactly three modes: DEMO, LIVE, and STANDBY', () => {


### PR DESCRIPTION
## Summary
- Bypass @researchflow/core package export resolution in the app-mode invariants test by importing from the source module.

## Typecheck totals
- Before: 813 errors / 188 files
- After: 811 errors / 187 files

## Grep proof (app-mode-invariants removed)
```
$ grep -n "app-mode-invariants.test.ts" typecheck.out
(no output)
```

## Top 10 TS codes after
```
311 TS2345
184 TS2305
126 TS2339
 61 TS2322
 20 TS2724
 15 TS2307
 10 TS2554
 10 TS2538
  9 TS2558
  8 TS2353
```

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F138&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->