### PR TITLE
fix(ts): correct boolean/string comparison in interactive elements e2e (TS2367)

### DIFF
--- a/researchflow-production-main/tests/e2e/interactive-elements.spec.ts
+++ b/researchflow-production-main/tests/e2e/interactive-elements.spec.ts
@@ -43,7 +43,7 @@ test.describe('ResearchFlow Interactive Elements Verification', () => {
           const isClickable = await card.evaluate(el => {
             return el.tagName === 'A' ||
                    el.hasAttribute('onclick') ||
-                   el.hasAttribute('role') === 'button' ||
+                   el.getAttribute('role') === 'button' ||
                    el.querySelector('a, button') !== null;
           });
           expect(isClickable || true).toBeTruthy(); // Log but don't fail


### PR DESCRIPTION
## Summary
- fix(ts): correct boolean/string comparison in interactive elements e2e (TS2367)

## Typecheck Totals
- Before: 812 errors / 187 files-with-errors
- After: 811 errors / 186 files-with-errors

## Grep Proof (TS2367 gone)
```
$ grep -n "interactive-elements.spec.ts" typecheck.out
# no matches
```

## Top 10 TS Codes (after)
```
 311 TS2345
 184 TS2305
 128 TS2339
  61 TS2322
  20 TS2724
  15 TS2307
  10 TS2554
  10 TS2538
   9 TS2558
   8 TS2353
```

## Files Changed
- tests/e2e/interactive-elements.spec.ts

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F139&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->