### PR TITLE
fix(ts): correct db import path in yjs-persistence.ts (TS2307)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/collaboration/yjs-persistence.ts
+++ b/researchflow-production-main/services/orchestrator/src/collaboration/yjs-persistence.ts
@@ -13,7 +13,7 @@
 
 import * as Y from 'yjs';
 
-import { db } from '../lib/db';
+import { db } from '../../db';
 
 export class YjsPersistence {
   /**


### PR DESCRIPTION
## PR140 Safe Single-File Fix

**File:** `services/orchestrator/src/collaboration/yjs-persistence.ts`

### Change
- **Before:** `import { db } from '../lib/db';`
- **After:** `import { db } from '../../db';`

### Safety Protocol Applied
✅ Selected file with **10 existing errors** (safe candidate)  
✅ Applied mechanical fix for TS2307 only  
✅ No other edits made

### Ratchet Verification
- **Before:** 811 total errors
- **After:** 810 total errors ✅
- **File errors:** 10 → 9 ✅
- **New errors:** 0 ✅

### Root Cause
The `lib/db` directory does not exist. The actual database module is at `services/orchestrator/db.ts`, requiring import path `../../db` from the collaboration subdirectory.

---
Part of phased TS2307 cleanup following strict safety protocol.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F140&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->