### PR TITLE
fix(ts): correct db import path in experiments route (TS2307)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/routes/experiments.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/experiments.ts
@@ -3,7 +3,7 @@ import { eq } from 'drizzle-orm';
 import express from 'express';
 import * as z from 'zod';
 
-import { db } from '../lib/db';
+import { db } from '../../db';
 import { asyncHandler } from '../middleware/asyncHandler';
 import { requireRole } from '../middleware/rbac';
 import { featureFlagsService } from '../services/featureFlagsService';


### PR DESCRIPTION
## PR141 Safe Single-File Fix

**File:** `services/orchestrator/src/routes/experiments.ts`

### Change
- **Before:** `import { db } from '../lib/db';`
- **After:** `import { db } from '../../db';`

### Safety Protocol Applied
✅ Selected file with **4 existing errors** (safe candidate)  
✅ Applied mechanical fix for TS2307 only  
✅ No other edits made

### Ratchet Verification
- **Before:** 810 total errors (14× TS2307)
- **After:** 809 total errors (13× TS2307) ✅
- **File errors:** 4 → 3 ✅
- **New errors:** 0 ✅

### Root Cause
The `lib/db` directory does not exist. The actual database module is at `services/orchestrator/db.ts`, requiring import path `../../db` from the routes subdirectory.

---
Part of phased TS2307 cleanup following strict safety protocol.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F141&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->