### PR TITLE
fix(ts): correct db import path in visualization route (TS2307)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/routes/visualization.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/visualization.ts
@@ -20,7 +20,7 @@ import * as z from 'zod';
 
 import { config } from '../config/env';
 import { visualizationConfig, getTimeoutForChartType, validateDataSize } from '../config/visualization.config';
-import { pool } from '../db';
+import { pool } from '../../db';
 import { asyncHandler } from '../middleware/asyncHandler';
 import { requirePermission } from '../middleware/rbac';
 import { VisualizationErrorHandler, validateVisualizationRequest } from '../middleware/visualization-error-handler';


### PR DESCRIPTION
## PR142 Safe Single-File Fix

**File:** services/orchestrator/src/routes/visualization.ts

### Change
- Before: import { pool } from '../db';
- After:  import { pool } from '../../db';

### Safety Protocol Applied
✅ Selected file with >1 existing errors (safe candidate)
✅ Mechanical TS2307 fix only
✅ No other edits

### Ratchet Verification
- Before: 809 total errors (13× TS2307)
- After:  808 total errors (12× TS2307) ✅
- File errors: 11 → 10 ✅
- New errors: 0 ✅

### Root Cause
The db module is at services/orchestrator/db.ts, requiring ../../db from routes

---
Part of phased TS2307 cleanup following strict safety protocol.