### PR TITLE
fix(ts): correct db import path in visualization metrics service (TS2307)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/services/visualization-metrics.service.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/visualization-metrics.service.ts
@@ -9,7 +9,7 @@
 import * as promClient from 'prom-client';
 
 import { visualizationConfig } from '../config/visualization.config';
-import { pool } from '../db';
+import { pool } from '../../db';
 import { createLogger } from '../utils/logger';
 
 import { visualizationCache } from './visualization-cache.service';


### PR DESCRIPTION
## Summary
- Fix TS2307 in visualization-metrics.service.ts by correcting db import path.

## Typecheck (canonical)
- Before: 808 errors (12× TS2307)
- After:  807 errors (11× TS2307) ✅
- Eliminated: TS2307 x1 in services/orchestrator/src/services/visualization-metrics.service.ts

## Change
- **File:** services/orchestrator/src/services/visualization-metrics.service.ts
- **Before:** `import { pool } from '../db';`
- **After:** `import { pool } from '../../db';`

## Root Cause
The db module is at services/orchestrator/db.ts, requiring ../../db from the services subdirectory.

## Scope
- Changed files (1):
  - services/orchestrator/src/services/visualization-metrics.service.ts

---
Part of phased TS2307 cleanup following strict safety protocol.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F143&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->