### PR TITLE
fix(ts): correct db import path in custom fields service (TS2307)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/services/customFieldsService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/customFieldsService.ts
@@ -2,7 +2,7 @@ import { orgCustomFields, entityCustomFieldValues, auditLogs } from '@researchfl
 import { eq, and, sql } from 'drizzle-orm';
 import * as z from 'zod';
 
-import { db } from '../lib/db';
+import { db } from '../../db';
 
 /**
  * Field Definition Schema


### PR DESCRIPTION
## Summary
- Fix TS2307 in customFieldsService.ts by correcting db import path.

## Typecheck (canonical)
- Before: 807 errors (11× TS2307)
- After:  806 errors (10× TS2307)
- Eliminated: TS2307 x1 in services/orchestrator/src/services/customFieldsService.ts

## Scope
- Changed files (1):
  - services/orchestrator/src/services/customFieldsService.ts

## Evidence
- TS2307 count decreased: 11 → 10 ✅
- Total errors decreased: 807 → 806 ✅
- No new errors introduced ✅

## Change
```diff
- import { db } from '../lib/db';
+ import { db } from '../../db';
```

## Root Cause
The `lib/db` directory does not exist. The actual database module is at `services/orchestrator/db.ts`, requiring import path `../../db` from the services subdirectory.

---
Part of phased TS2307 cleanup following strict safety protocol.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F144&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->