### PR TITLE
fix(ts2307): correct orchestrator db import paths (services)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/services/favoritesService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/favoritesService.ts
@@ -1,4 +1,4 @@
-import { pool } from '../db.js';
+import { pool } from '../../db';
 
 export type FavoriteResourceType = 'project' | 'workflow' | 'artifact' | 'paper';
 

--- a/researchflow-production-main/services/orchestrator/src/services/featureFlagsService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/featureFlagsService.ts
@@ -3,7 +3,7 @@ import crypto from 'crypto';
 import { featureFlags, experiments, experimentAssignments } from '@researchflow/core/types/schema';
 import { eq, and } from 'drizzle-orm';
 
-import { db } from '../lib/db';
+import { db } from '../../db';
 
 
 /**


### PR DESCRIPTION
## Summary
- Fix TS2307 missing-module errors caused by incorrect relative db import paths in orchestrator services.
- Mechanical path correction only; no refactors, no tsconfig/deps, no formatting.

## Scope / Root cause
- Single root cause: incorrect relative db imports (`../lib/db`, `../db.js`) resolving to non-existent paths.

## Changes (exact)
- services/orchestrator/src/services/featureFlagsService.ts
  - `../lib/db` → `../../db`
- services/orchestrator/src/services/favoritesService.ts
  - `../db.js` → `../../db`

## Typecheck (canonical)
- Command: `pnpm run typecheck 2>&1 | tee typecheck.out`
- Before: 806 total errors (10× TS2307)
- After: 804 total errors (8× TS2307) ✅
- Top TS codes:
  ```
 311 TS2345
 184 TS2305
 128 TS2339
  61 TS2322
  20 TS2724
  10 TS2554
  10 TS2538
   9 TS2558
   8 TS2353
   8 TS2307
  ```
- TS2307 lines: Reduced by 2 (10 → 8) ✅

## Verification
- Only 2 files changed ✅
- Total errors decreased by 2 (806 → 804) ✅
- No new errors in edited files ✅

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F145&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->