### PR TITLE
fix(ts2307): correct phi-scanner import path in integration test

### DIFF
--- a/researchflow-production-main/tests/integration/phi-scanner-orchestrator.test.ts
+++ b/researchflow-production-main/tests/integration/phi-scanner-orchestrator.test.ts
@@ -42,7 +42,7 @@ vi.mock('@researchflow/phi-engine', () => ({
 }));
 
 // Import after mocking
-import { scanForPHI, type PHIPattern, type PHIScanResult } from '../../../../services/orchestrator/services/phi-scanner';
+import { scanForPHI, type PHIPattern, type PHIScanResult } from '../../services/orchestrator/services/phi-scanner';
 
 describe('PHI Scanner Safety', () => {
   describe('scanForPHI - Hash-only Output', () => {


### PR DESCRIPTION
## Safe Single-File TS2307 Fix

**File:** tests/integration/phi-scanner-orchestrator.test.ts

### Change
- **Before:** `import { scanForPHI, type PHIPattern, type PHIScanResult } from '../../../../services/orchestrator/services/phi-scanner';`
- **After:** `import { scanForPHI, type PHIPattern, type PHIScanResult } from '../../services/orchestrator/services/phi-scanner';`

### Safety Protocol Applied
✅ Single integration test file  
✅ Mechanical path correction only  
✅ No other edits made

### Ratchet Verification
- **Before (main):** 803 total errors, 7× TS2307
- **After (fix):** 802 total errors, 6× TS2307 ✅
- **Decrease:** 1 total error ✅
- **File errors:** Integration test now resolves correctly ✅
- **New errors:** 0 ✅

### Root Cause
The phi-scanner module is located at `services/orchestrator/services/phi-scanner.ts`. The test file at `tests/integration/phi-scanner-orchestrator.test.ts` requires the relative path `../../services/orchestrator/services/phi-scanner` (not via `src/services/`).

### Canonical Top TS Error Codes (After Fix)
```
 311 TS2345
 184 TS2305
 128 TS2339
  61 TS2322
  20 TS2724
  10 TS2554
  10 TS2538
   9 TS2558
   8 TS2353
   7 TS2304
```
(TS2307 reduced to 6 occurrences, no longer in top 10)

---
Part of phased TS2307 cleanup following strict safety protocol.
