### PR TITLE
fix(ts2307): correct n8n config import path

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/integrations/n8n.ts
+++ b/researchflow-production-main/services/orchestrator/src/integrations/n8n.ts
@@ -7,7 +7,7 @@
  * - Multi-service orchestration
  */
 
-import { config } from '../config';
+import { config } from '../config/env';
 
 interface N8nWorkflow {
   id: string;


### PR DESCRIPTION
## PR148 Safe Single-File Fix

**File:** services/orchestrator/src/integrations/n8n.ts

### Change
- **Before:** `import { config } from '../config';`
- **After:** `import { config } from '../config/env';`

### Safety Protocol Applied
✅ Single mechanical import path correction
✅ Aligned with codebase pattern (all other files import from '../config/env')
✅ No other edits made

### Ratchet Verification
- **Total errors:** 801 ✅
- **TS2307 count:** 5 (down from baseline) ✅
- **File errors:** 0 (n8n.ts now clean) ✅
- **New errors:** 0 ✅

### Top TS Error Codes
```
 311 TS2345
 184 TS2305
 128 TS2339
  61 TS2322
  20 TS2724
  10 TS2554
  10 TS2538
   9 TS2558
   8 TS2353
   7 TS2304
```

### Root Cause
The import path `'../config'` was incorrect. The actual config module exports a `config` object from `src/config/env.ts`. All other files in the codebase correctly import from `'../config/env'` or `'../../config/env'`.

---
Part of phased TS2307 cleanup following strict safety protocol.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F148&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->