### PR TITLE
fix(ts2307): correct branches.routes import path

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/routes/branches.routes.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/branches.routes.ts
@@ -15,7 +15,7 @@
 
 import { Router, Request, Response } from 'express';
 
-import { branchPersistenceService } from './branch-persistence.service';
+import { branchPersistenceService } from '../services/branch-persistence.service';
 
 const router = Router();
 


### PR DESCRIPTION
## Safe Single-File Fix

**File:** `services/orchestrator/src/routes/branches.routes.ts`

### Change
- **Before:** `import { branchPersistenceService } from './branch-persistence.service';`
- **After:** `import { branchPersistenceService } from '../services/branch-persistence.service';`

### Safety Protocol Applied
✅ Single file edit only  
✅ Mechanical import path fix  
✅ No refactors, no suppressions  

### Ratchet Verification
- **Before total errors:** ~811 TS errors, 5× TS2307
- **After total errors:** ~804 TS errors, 4× TS2307 ✅
- **TS2307 reduced:** 5 → 4 ✅
- **New errors:** 0 ✅

### Top TS Error Codes (After Fix)
```
 317 TS2345
 184 TS2305
 128 TS2339
  63 TS2322
  20 TS2724
  10 TS2554
  10 TS2538
   9 TS2558
   8 TS2353
   7 TS2304
```

### Root Cause
The `branch-persistence.service` file is located at `services/orchestrator/src/services/branch-persistence.service.ts`, not in the same directory as `branches.routes.ts`. The correct relative path from routes subdirectory requires `../services/`.

---
Part of phased TS2307 cleanup following strict safety protocol.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F149&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->