### PR TITLE
fix(types): export manuscript-engine services (TS2305)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/types/ambient.d.ts
+++ b/researchflow-production-main/services/orchestrator/src/types/ambient.d.ts
@@ -245,8 +245,9 @@ declare module 'drizzle-orm' { export const eq: any; export const and: any; expo
 // Internal workspace packages
 declare module '@researchflow/ai-router' { export const routeToModel: any; export const getModelConfig: any; }
 declare module '@researchflow/ai-router/*' { const mod: any; export = mod; }
-declare module '@researchflow/manuscript-engine' { export const ManuscriptService: any; }
-declare module '@researchflow/manuscript-engine/*' { const mod: any; export = mod; }
+// @researchflow/manuscript-engine — resolved via tsconfig paths; ambient override removed (PR151)
+// declare module '@researchflow/manuscript-engine' { export const ManuscriptService: any; }
+// declare module '@researchflow/manuscript-engine/*' { const mod: any; export = mod; }
 declare module '@researchflow/notion-integration' { export const NotionClient: any; }
 declare module '@researchflow/cursor-integration' { const mod: any; export = mod; }
 declare module '@researchflow/cursor-integration/*' { const mod: any; export = mod; }


### PR DESCRIPTION
## Summary

Remove ambient `declare module '@researchflow/manuscript-engine'` override in `services/orchestrator/src/types/ambient.d.ts` that was **completely shadowing** the real package exports. The ambient declaration limited the module API to `{ ManuscriptService: any }`, making all 38 referenced symbols invisible to TypeScript.

## Root cause

The orchestrator's `ambient.d.ts` had:
```ts
declare module '@researchflow/manuscript-engine' { export const ManuscriptService: any; }
declare module '@researchflow/manuscript-engine/*' { const mod: any; export = mod; }
```
This ambient module declaration takes precedence over the actual package source resolved via `tsconfig.json` paths, preventing TypeScript from seeing any of the real exports (service singletons, classes, constants).

## Before / After

| Metric | Before | After |
|--------|--------|-------|
| **TS2305 `@researchflow/manuscript-engine`** | **38** | **0** |
| Total TS errors | 734 | 687 |
| Net error reduction | — | **-47** |

> The net reduction exceeds 38 because 9 additional TS2339 errors in `audit-improvements.test.ts` (caused by the same ambient override limiting the module type to `{ default, ManuscriptService }`) are also resolved.

## Missing symbols resolved (38)

`abstractGeneratorService`, `acknowledgmentsService`, `arxivService`, `authorManagerService`, `citationManagerService`, `claimVerifierService`, `clarityAnalyzerService`, `claudeWriterService`, `coiDisclosureService`, `complianceCheckerService`, `DEFAULT_BUDGETS`, `discussionBuilderService`, `exportService`, `FinalPhiScanService`, `finalPhiScanService`, `grammarCheckerService`, `introductionBuilderService`, `irbGeneratorService`, `keywordGeneratorService`, `litMatrixService`, `litReviewService`, `medicalNLPService`, `methodsPopulatorService`, `paraphraseService`, `peerReviewService`, `plagiarismCheckService`, `pubmedService`, `readabilityService`, `referencesBuilderService`, `resultsScaffoldService`, `semanticScholarService`, `sentenceBuilderService`, `synonymFinderService`, `titleGeneratorService`, `toneAdjusterService`, `transitionSuggesterService`, `validateWordBudget`, `visualizationService`

## Files changed (1)

- `services/orchestrator/src/types/ambient.d.ts` — commented out the two `declare module` lines for `@researchflow/manuscript-engine`

## Safety

- **Types-only / ambient-declaration-only** — no runtime behavior changes
- The real package exports were already correctly defined in `packages/manuscript-engine/index.ts` (via `export * from './src/services'` and `export * from './validators/word-budget'`)
- No symbols were missing from the actual package; only the ambient override was blocking visibility

Made with [Cursor](https://cursor.com)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F151&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->