### PR TITLE
fix(ts): normalize req.params values in research & data routes (TS2345 batch 2)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/routes/artifact-graph.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/artifact-graph.ts
@@ -12,6 +12,7 @@ import * as z from "zod";
 
 import { requireRole } from "../middleware/rbac";
 import * as artifactGraphService from "../services/artifactGraphService";
+import { asString } from "../utils/asString";
 import { createAuditEntry } from "../services/auditService";
 
 const router = Router();
@@ -52,7 +53,7 @@ router.get(
   requireRole("VIEWER"),
   async (req: Request, res: Response) => {
     try {
-      const { artifactId } = req.params;
+      const artifactId = asString(req.params.artifactId);
       const queryResult = graphQuerySchema.safeParse(req.query);
       
       if (!queryResult.success) {
@@ -136,7 +137,7 @@ router.delete(
   requireRole("RESEARCHER"),
   async (req: Request, res: Response) => {
     try {
-      const { edgeId } = req.params;
+      const edgeId = asString(req.params.edgeId);
       
       // Get edge details for audit log
       const edge = await artifactGraphService.getEdge(edgeId);
@@ -211,7 +212,7 @@ router.get(
   requireRole("VIEWER"),
   async (req: Request, res: Response) => {
     try {
-      const { edgeId } = req.params;
+      const edgeId = asString(req.params.edgeId);
       const edge = await artifactGraphService.getEdge(edgeId);
 
       if (!edge) {

--- a/researchflow-production-main/services/orchestrator/src/routes/artifact-versions.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/artifact-versions.ts
@@ -18,6 +18,7 @@ import * as z from "zod";
 
 import { db } from "../../db";
 import { requireRole } from "../middleware/rbac";
+import { asString } from "../utils/asString";
 import { createAuditEntry } from "../services/auditService";
 import * as diffService from "../services/diffService";
 
@@ -55,7 +56,7 @@ router.get(
   requireRole("VIEWER"),
   async (req: Request, res: Response) => {
     try {
-      const { artifactId } = req.params;
+      const artifactId = asString(req.params.artifactId);
       const parseResult = listVersionsSchema.safeParse(req.query);
 
       if (!parseResult.success) {
@@ -117,7 +118,8 @@ router.get(
   requireRole("VIEWER"),
   async (req: Request, res: Response) => {
     try {
-      const { artifactId, versionId } = req.params;
+      const artifactId = asString(req.params.artifactId);
+      const versionId = asString(req.params.versionId);
       const includeContent = req.query.includeContent === 'true';
 
       const [version] = await db
@@ -169,7 +171,7 @@ router.post(
   requireRole("RESEARCHER"),
   async (req: Request, res: Response) => {
     try {
-      const { artifactId } = req.params;
+      const artifactId = asString(req.params.artifactId);
       const parseResult = createVersionSchema.safeParse(req.body);
 
       if (!parseResult.success) {
@@ -275,7 +277,7 @@ router.post(
   requireRole("VIEWER"),
   async (req: Request, res: Response) => {
     try {
-      const { artifactId } = req.params;
+      const artifactId = asString(req.params.artifactId);
       const parseResult = compareVersionsSchema.safeParse(req.body);
 
       if (!parseResult.success) {
@@ -336,7 +338,8 @@ router.post(
   requireRole("RESEARCHER"),
   async (req: Request, res: Response) => {
     try {
-      const { artifactId, versionId } = req.params;
+      const artifactId = asString(req.params.artifactId);
+      const versionId = asString(req.params.versionId);
       const userId = (req as any).user?.id;
 
       // Get the version to restore

--- a/researchflow-production-main/services/orchestrator/src/routes/billing.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/billing.ts
@@ -19,6 +19,7 @@ import { Router, Request, Response } from "express";
 
 import { db } from "../../db";
 import { asyncHandler } from "../middleware/asyncHandler";
+import { asString } from "../utils/asString";
 import { requireAuth as isAuthenticated } from "../middleware/auth.js";
 import {
   resolveOrgContext,
@@ -49,7 +50,7 @@ router.get(
   resolveOrgContext(),
   requireOrgId(),
   asyncHandler(async (req: Request, res: Response) => {
-    const orgId = req.params.orgId;
+    const orgId = asString(req.params.orgId);
 
     const subscription = await getOrgSubscription(orgId);
 
@@ -72,7 +73,7 @@ router.get(
   resolveOrgContext(),
   requireOrgId(),
   asyncHandler(async (req: Request, res: Response) => {
-    const orgId = req.params.orgId;
+    const orgId = asString(req.params.orgId);
 
     if (!db) {
       return res.status(503).json({ error: "Database not available" });
@@ -136,7 +137,7 @@ router.post(
   requireOrgId(),
   requireOrgCapability("billing"),
   asyncHandler(async (req: Request, res: Response) => {
-    const orgId = req.params.orgId;
+    const orgId = asString(req.params.orgId);
     const userId = (req.user as any)?.id;
     const { tier } = req.body;
 
@@ -187,7 +188,7 @@ router.post(
   requireOrgId(),
   requireOrgCapability("billing"),
   asyncHandler(async (req: Request, res: Response) => {
-    const orgId = req.params.orgId;
+    const orgId = asString(req.params.orgId);
     const userId = (req.user as any)?.id;
 
     try {
@@ -237,7 +238,7 @@ router.post(
       return res.status(403).json({ error: "Not available in production" });
     }
 
-    const orgId = req.params.orgId;
+    const orgId = asString(req.params.orgId);
     const userId = (req.user as any)?.id;
     const { tier } = req.body;
 
@@ -278,7 +279,7 @@ router.get(
   resolveOrgContext(),
   requireOrgId(),
   asyncHandler(async (req: Request, res: Response) => {
-    const orgId = req.params.orgId;
+    const orgId = asString(req.params.orgId);
     const resource = req.params.resource as "members" | "projects" | "aiCalls" | "storage";
 
     const validResources = ["members", "projects", "aiCalls", "storage"];

--- a/researchflow-production-main/services/orchestrator/src/routes/cumulative-data.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/cumulative-data.ts
@@ -10,6 +10,7 @@
 import { Router, Request, Response } from 'express';
 import * as z from 'zod';
 
+import { asString } from '../utils/asString';
 import {
   getCumulativeDataService,
   WORKFLOW_STAGES,
@@ -67,7 +68,7 @@ router.get('/stages', (_req: Request, res: Response) => {
  */
 router.get('/projects/:identifier/state', async (req: Request, res: Response) => {
   try {
-    const { identifier } = req.params;
+    const identifier = asString(req.params.identifier);
     const service = getCumulativeDataService();
 
     // Determine if identifier is a projectId or researchId
@@ -94,7 +95,8 @@ router.get('/projects/:identifier/state', async (req: Request, res: Response) =>
  */
 router.get('/projects/:identifier/cumulative/:stageNumber', async (req: Request, res: Response) => {
   try {
-    const { identifier, stageNumber } = req.params;
+    const identifier = asString(req.params.identifier);
+    const stageNumber = asString(req.params.stageNumber);
     const stageNum = parseInt(stageNumber, 10);
 
     if (isNaN(stageNum) || stageNum < 1 || stageNum > 20) {
@@ -133,7 +135,8 @@ router.get('/projects/:identifier/cumulative/:stageNumber', async (req: Request,
  */
 router.post('/projects/:identifier/stages/:stageNumber', async (req: Request, res: Response) => {
   try {
-    const { identifier, stageNumber } = req.params;
+    const identifier = asString(req.params.identifier);
+    const stageNumber = asString(req.params.stageNumber);
     const stageNum = parseInt(stageNumber, 10);
 
     if (isNaN(stageNum) || stageNum < 1 || stageNum > 20) {
@@ -269,7 +272,7 @@ router.post('/internal/stages/fail', async (req: Request, res: Response) => {
  */
 router.post('/projects/:identifier/phi-schema', async (req: Request, res: Response) => {
   try {
-    const { identifier } = req.params;
+    const identifier = asString(req.params.identifier);
 
     const validation = PhiSchemaSchema.safeParse(req.body);
     if (!validation.success) {
@@ -308,7 +311,8 @@ router.post('/projects/:identifier/phi-schema', async (req: Request, res: Respon
  */
 router.get('/projects/:identifier/stages/:stageNumber', async (req: Request, res: Response) => {
   try {
-    const { identifier, stageNumber } = req.params;
+    const identifier = asString(req.params.identifier);
+    const stageNumber = asString(req.params.stageNumber);
     const stageNum = parseInt(stageNumber, 10);
 
     if (isNaN(stageNum) || stageNum < 1 || stageNum > 20) {

--- a/researchflow-production-main/services/orchestrator/src/routes/custom-fields.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/custom-fields.ts
@@ -3,6 +3,7 @@ import * as z from 'zod';
 
 import { asyncHandler } from '../middleware/asyncHandler';
 import { customFieldsService, CustomFieldsSchemaValidator } from '../services/customFieldsService';
+import { asString } from '../utils/asString';
 
 const router = express.Router();
 
@@ -18,7 +19,7 @@ const router = express.Router();
 router.get('/:entityType/schema',
   // TODO: Add requirePermission('VIEW') middleware
   asyncHandler(async (req, res) => {
-    const { entityType } = req.params;
+    const entityType = asString(req.params.entityType);
     const orgId = req.headers['x-organization-id'] as string || req.query.orgId as string;
 
     if (!orgId) {
@@ -60,7 +61,7 @@ router.put('/:entityType/schema',
   // TODO: Add blockInStandby() middleware
   // TODO: Add requireRole('ADMIN') middleware
   asyncHandler(async (req, res) => {
-    const { entityType } = req.params;
+    const entityType = asString(req.params.entityType);
     const orgId = req.headers['x-organization-id'] as string || req.query.orgId as string;
     const userId = req.user?.id || 'system';
 
@@ -108,7 +109,8 @@ router.put('/:entityType/schema',
 router.get('/:entityType/:entityId/values',
   // TODO: Add requirePermission('VIEW') middleware
   asyncHandler(async (req, res) => {
-    const { entityType, entityId } = req.params;
+    const entityType = asString(req.params.entityType);
+    const entityId = asString(req.params.entityId);
     const orgId = req.headers['x-organization-id'] as string || req.query.orgId as string;
 
     if (!orgId) {
@@ -136,7 +138,8 @@ router.put('/:entityType/:entityId/values',
   // TODO: Add blockInStandby() middleware
   // TODO: Add requirePermission('CREATE') middleware
   asyncHandler(async (req, res) => {
-    const { entityType, entityId } = req.params;
+    const entityType = asString(req.params.entityType);
+    const entityId = asString(req.params.entityId);
     const orgId = req.headers['x-organization-id'] as string || req.query.orgId as string;
 
     if (!orgId) {
@@ -168,7 +171,8 @@ router.delete('/:entityType/:entityId/values',
   // TODO: Add blockInStandby() middleware
   // TODO: Add requirePermission('DELETE') middleware
   asyncHandler(async (req, res) => {
-    const { entityType, entityId } = req.params;
+    const entityType = asString(req.params.entityType);
+    const entityId = asString(req.params.entityId);
     const orgId = req.headers['x-organization-id'] as string || req.query.orgId as string;
 
     if (!orgId) {
@@ -197,7 +201,7 @@ router.delete('/:entityType/:entityId/values',
 router.get('/:entityType/entities',
   // TODO: Add requirePermission('VIEW') middleware
   asyncHandler(async (req, res) => {
-    const { entityType } = req.params;
+    const entityType = asString(req.params.entityType);
     const orgId = req.headers['x-organization-id'] as string || req.query.orgId as string;
 
     if (!orgId) {

--- a/researchflow-production-main/services/orchestrator/src/routes/datasets.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/datasets.ts
@@ -14,6 +14,7 @@ import { Router } from 'express';
 
 import { db } from '../../db.js';
 import { blockDataUploadInDemo } from '../../middleware/mode-guard.js';
+import { asString } from '../utils/asString';
 import { asyncHandler } from '../middleware/errorHandler.js';
 import {
   blockInStandby,
@@ -71,7 +72,7 @@ router.get(
   '/:datasetId',
   requirePermission('VIEW'),
   asyncHandler(async (req, res) => {
-    const { datasetId } = req.params;
+    const datasetId = asString(req.params.datasetId);
 
     const dataset = await getDatasetById(datasetId);
 
@@ -282,7 +283,7 @@ router.delete(
   blockInStandby(),
   requirePermission('DELETE'),
   asyncHandler(async (req, res) => {
-    const { datasetId } = req.params;
+    const datasetId = asString(req.params.datasetId);
 
     // Get dataset first for audit logging
     const dataset = await getDatasetById(datasetId);
@@ -343,7 +344,7 @@ router.post(
   blockInStandby(),
   requirePermission('APPROVE'),
   asyncHandler(async (req, res) => {
-    const { datasetId } = req.params;
+    const datasetId = asString(req.params.datasetId);
 
     const dataset = await getDatasetById(datasetId);
 

--- a/researchflow-production-main/services/orchestrator/src/routes/shares.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/shares.ts
@@ -15,6 +15,7 @@ import * as z from "zod";
 import { requireRole } from "../middleware/rbac";
 import { createAuditEntry } from "../services/auditService";
 import * as shareService from "../services/shareService";
+import { asString } from "../utils/asString";
 
 const router = Router();
 
@@ -148,7 +149,7 @@ router.get(
   requireRole("RESEARCHER"),
   async (req: Request, res: Response) => {
     try {
-      const { shareId } = req.params;
+      const shareId = asString(req.params.shareId);
 
       const share = await shareService.getShare(shareId);
 
@@ -174,7 +175,7 @@ router.post(
   requireRole("RESEARCHER"),
   async (req: Request, res: Response) => {
     try {
-      const { shareId } = req.params;
+      const shareId = asString(req.params.shareId);
       const userId = (req as any).user?.id || "system";
 
       const existing = await shareService.getShare(shareId);
@@ -216,7 +217,7 @@ router.post(
   requireRole("RESEARCHER"),
   async (req: Request, res: Response) => {
     try {
-      const { shareId } = req.params;
+      const shareId = asString(req.params.shareId);
       const userId = (req as any).user?.id || "system";
 
       const parseResult = extendShareSchema.safeParse(req.body);

--- a/researchflow-production-main/services/orchestrator/src/routes/statistical-analysis.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/statistical-analysis.ts
@@ -17,6 +17,7 @@ import * as z from 'zod';
 import { config } from '../config/env';
 import { asyncHandler } from '../middleware/asyncHandler';
 import { requirePermission } from '../middleware/rbac';
+import { asString } from '../utils/asString';
 import { logAction } from '../services/audit-service';
 import { createLogger } from '../utils/logger';
 
@@ -81,7 +82,7 @@ router.post(
   requirePermission('ANALYZE'),
   asyncHandler(async (req: Request, res: Response) => {
     const startTime = Date.now();
-    const researchId = req.params.id;
+    const researchId = asString(req.params.id);
     const requestId = `stat_analysis_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
 
     logger.info('Statistical analysis requested', { researchId, requestId });

--- a/researchflow-production-main/services/orchestrator/src/routes/statistical-recommendations.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/statistical-recommendations.ts
@@ -13,6 +13,7 @@ import * as z from 'zod';
 import { config } from '../config/env';
 import { asyncHandler } from '../middleware/asyncHandler';
 import { requirePermission } from '../middleware/rbac';
+import { asString } from '../utils/asString';
 
 const router = Router();
 const WORKER_URL = config.workerUrl;
@@ -139,7 +140,7 @@ router.get(
   '/assumption-tests/:method',
   requirePermission('ANALYZE'),
   asyncHandler(async (req: Request, res: Response) => {
-    const method = req.params.method;
+    const method = asString(req.params.method);
     if (!method || !method.trim()) {
       return res.status(400).json({
         error: 'INVALID_PARAM',

--- a/researchflow-production-main/services/orchestrator/src/routes/topics.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/topics.ts
@@ -5,6 +5,7 @@ import { Router } from "express";
 
 import { db } from "../../db";
 import { asyncHandler } from "../middleware/errorHandler";
+import { asString } from "../utils/asString";
 import { requireRole, logAuditEvent, ROLES } from "../middleware/rbac";
 import {
   convertQuickEntryToPICO,
@@ -26,7 +27,7 @@ const router = Router();
 router.get(
   "/:researchId",
   asyncHandler(async (req, res) => {
-    const { researchId } = req.params;
+    const researchId = asString(req.params.researchId);
 
     const topic = await getCurrentTopic(researchId);
 
@@ -46,7 +47,7 @@ router.get(
 router.get(
   "/:researchId/history",
   asyncHandler(async (req, res) => {
-    const { researchId } = req.params;
+    const researchId = asString(req.params.researchId);
 
     const history = await getTopicVersionHistory(researchId);
 
@@ -106,7 +107,7 @@ router.post(
 router.put(
   "/:id",
   asyncHandler(async (req, res) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     const { title, description, picoElements, keywords } = req.body;
     const userId = req.user?.id || "anonymous";
 
@@ -148,7 +149,7 @@ router.put(
 router.post(
   "/:id/lock",
   asyncHandler(async (req, res) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     const userId = req.user?.id || "anonymous";
 
     const existingTopic = await getTopicById(id);
@@ -197,7 +198,7 @@ router.post(
   requireRole(ROLES.RESEARCHER),
   logAuditEvent("TOPIC_CONVERT_TO_PICO", "topic"),
   asyncHandler(async (req, res) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     const { comparator, timeframe, population, intervention }: PICOConversionRequest = req.body;
 
     const existingTopic = await getTopicById(id);
@@ -284,7 +285,7 @@ router.post(
 router.get(
   "/:id/entry-mode",
   asyncHandler(async (req, res) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
 
     const topic = await getTopicById(id);
     if (!topic) {


### PR DESCRIPTION
## Summary

Apply the existing `asString()` helper (from PR #152) to 10 orchestrator route files to resolve TS2345/TS2322 errors caused by Express `req.params` values typed as `string | string[]`.

Mechanical wrapping only — no logic, routing, or dependency changes.

## Files Changed (10)

| File | Errors Fixed | Pattern |
|------|-------------|---------|
| `cumulative-data.ts` | 13 | `identifier`, `stageNumber` from `req.params` |
| `custom-fields.ts` | 9 | `entityType`, `entityId` from `req.params` |
| `topics.ts` | 9 | `researchId`, `id` from `req.params` |
| `billing.ts` | 6 | `orgId` from `req.params` |
| `datasets.ts` | 5 | `datasetId` from `req.params` |
| `shares.ts` | 5 | `shareId` from `req.params` |
| `artifact-graph.ts` | 4 | `artifactId`, `edgeId` from `req.params` |
| `statistical-analysis.ts` | 2 | `researchId` from `req.params` (TS2322 + TS2769) |
| `artifact-versions.ts` | 1 | `artifactId` from `req.params` |
| `statistical-recommendations.ts` | 1 | `method` from `req.params` |

### Skipped (no string\|string[] errors)

- `research-brief.ts` — only has TS2724 (schema export naming)
- `sap.ts` — only has TS2724 (schema export naming)

## Scope / Safety

- **Single root cause**: TS2345/TS2322 from Express `req.params` union types
- Uses existing `asString()` helper from batch 1 (PR #152)
- No dependency changes, no tsconfig changes, no ambient declarations
- Runtime semantics preserved (no coercion of `undefined` to `""`)

## Typecheck Evidence

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Total errors | 641 | 582 | **-59** |
| TS2345 errors | 272 | 220 | **-52** |

Command: `npx tsc --noEmit` from `researchflow-production-main/`

## Cumulative Progress (batches 1+2)

| Metric | Original | After Batch 2 | Total Delta |
|--------|----------|---------------|-------------|
| Total errors | 687 | 582 | **-105** |
| TS2345 errors | 317 | 220 | **-97** |

Made with [Cursor](https://cursor.com)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F153&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->