### PR TITLE
fix(ts): normalize req.params in PHI, chat & docs-first routes (TS2345 batch 6)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/routes/docs-first/doc-kits.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/docs-first/doc-kits.ts
@@ -10,6 +10,7 @@ import { asyncHandler } from '../../middleware/asyncHandler.js';
 import { blockInStandby } from '../../middleware/governance-gates.js';
 import { requirePermission } from '../../middleware/rbac.js';
 import { docKitsService } from '../../services/docs-first/doc-kits.service.js';
+import { asString } from '../../utils/asString';
 
 const router = express.Router();
 
@@ -52,7 +53,7 @@ router.post('/',
 router.get('/:id',
   requirePermission('VIEW'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
 
     try {
       const result = await docKitsService.getKitWithItems(id);
@@ -74,7 +75,7 @@ router.patch('/items/:id',
   blockInStandby(),
   requirePermission('UPDATE'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     const { status, content } = req.body;
 
     if (!status) {

--- a/researchflow-production-main/services/orchestrator/src/routes/docs-first/ideas.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/docs-first/ideas.ts
@@ -11,6 +11,7 @@ import { asyncHandler } from '../../middleware/asyncHandler.js';
 import { blockInStandby } from '../../middleware/governance-gates.js';
 import { requirePermission } from '../../middleware/rbac.js';
 import { ideasService } from '../../services/docs-first/ideas.service.js';
+import { asString } from '../../utils/asString';
 
 
 const router = express.Router();
@@ -82,7 +83,7 @@ router.get('/',
 router.get('/:id',
   requirePermission('VIEW'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     const idea = await ideasService.getIdea(id);
 
     if (!idea) {
@@ -102,7 +103,7 @@ router.patch('/:id',
   requirePermission('UPDATE'),
   asyncHandler(async (req: Request, res: Response) => {
     try {
-      const { id } = req.params;
+      const id = asString(req.params.id);
       const updates = UpdateIdeaSchema.parse(req.body);
 
       const idea = await ideasService.updateIdea(id, updates, req.user!.id);
@@ -126,7 +127,7 @@ router.delete('/:id',
   blockInStandby(),
   requirePermission('DELETE'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     await ideasService.deleteIdea(id, req.user!.id);
 
     res.status(204).send();
@@ -139,7 +140,7 @@ router.post('/:id/scorecard',
   requirePermission('CREATE'),
   asyncHandler(async (req: Request, res: Response) => {
     try {
-      const { id } = req.params;
+      const id = asString(req.params.id);
       const scores = ScorecardSchema.parse(req.body);
 
       const scorecard = await ideasService.createOrUpdateScorecard(
@@ -166,7 +167,7 @@ router.post('/:id/scorecard',
 router.get('/:id/scorecard',
   requirePermission('VIEW'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     const scorecard = await ideasService.getScorecard(id);
 
     if (!scorecard) {
@@ -185,7 +186,7 @@ router.post('/:id/convert',
   blockInStandby(),
   requirePermission('CREATE'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     const briefId = await ideasService.convertToTopicBrief(id, req.user!.id);
 
     res.status(201).json({

--- a/researchflow-production-main/services/orchestrator/src/routes/docs-first/topic-briefs.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/docs-first/topic-briefs.ts
@@ -15,6 +15,7 @@ import { blockInStandby } from '../../middleware/governance-gates.js';
 import { requirePermission, requireRole } from '../../middleware/rbac.js';
 import { scopeFreezeService } from '../../services/docs-first/scope-freeze.service.js';
 import { topicBriefsService } from '../../services/docs-first/topic-briefs.service.js';
+import { asString } from '../../utils/asString';
 
 const router = express.Router();
 
@@ -74,7 +75,7 @@ router.get('/',
 router.get('/:id',
   requirePermission('VIEW'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     const brief = await topicBriefsService.getBrief(id);
 
     if (!brief) {
@@ -93,7 +94,7 @@ router.patch('/:id',
   blockInStandby(),
   requirePermission('UPDATE'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
 
     try {
       const brief = await topicBriefsService.updateBrief(id, req.body, req.user!.id);
@@ -115,7 +116,7 @@ router.delete('/:id',
   blockInStandby(),
   requirePermission('DELETE'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     await topicBriefsService.deleteBrief(id, req.user!.id);
     res.status(204).send();
   })
@@ -126,7 +127,7 @@ router.post('/:id/freeze',
   blockInStandby(),
   requireRole('STEWARD'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
 
     try {
       const anchor = await scopeFreezeService.freezeBrief(id, req.user!.id);
@@ -156,7 +157,7 @@ router.post('/:id/freeze',
 router.get('/:id/snapshot',
   requirePermission('VIEW'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
 
     const snapshot = await scopeFreezeService.getLatestSnapshot(id);
 
@@ -175,7 +176,7 @@ router.get('/:id/snapshot',
 router.get('/anchors/:id/verify',
   requirePermission('VIEW'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     const result = await scopeFreezeService.verifyAnchor(id);
 
     res.json(result);

--- a/researchflow-production-main/services/orchestrator/src/routes/phaseChatRoutes.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/phaseChatRoutes.ts
@@ -16,6 +16,7 @@ import {
   STAGE_TO_AGENTS,
 } from '../services/phase-chat/registry';
 import { phaseChatService } from '../services/phase-chat/service';
+import { asString } from '../utils/asString';
 
 const router = Router();
 
@@ -35,7 +36,7 @@ const PhaseChatInputSchema = z.object({
  */
 router.get('/:stage/agents', async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const stage = parseInt(req.params.stage, 10);
+    const stage = parseInt(asString(req.params.stage), 10);
 
     if (isNaN(stage) || stage < 1 || stage > 20) {
       return res.status(400).json({
@@ -67,7 +68,7 @@ router.get('/:stage/agents', async (req: Request, res: Response, next: NextFunct
  */
 router.post('/:stage/chat', async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const stage = parseInt(req.params.stage, 10);
+    const stage = parseInt(asString(req.params.stage), 10);
     const parseResult = PhaseChatInputSchema.safeParse(req.body);
 
     if (isNaN(stage) || stage < 1 || stage > 20) {
@@ -139,8 +140,8 @@ router.post('/:stage/chat', async (req: Request, res: Response, next: NextFuncti
  */
 router.post('/:stage/chat/:agentId', async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const stage = parseInt(req.params.stage, 10);
-    const { agentId } = req.params;
+    const stage = parseInt(asString(req.params.stage), 10);
+    const agentId = asString(req.params.agentId);
     const parseResult = PhaseChatInputSchema.safeParse(req.body);
 
     if (isNaN(stage) || stage < 1 || stage > 20) {

--- a/researchflow-production-main/services/orchestrator/src/routes/phi-scanner.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/phi-scanner.ts
@@ -22,6 +22,7 @@ import {
   updateAccessRequest,
   listAccessRequests,
 } from '../services/phi-scan-persistence.service';
+import { asString } from '../utils/asString';
 
 const router = Router();
 
@@ -300,7 +301,7 @@ router.get(
   '/scan/:id',
   requirePermission('ANALYZE'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     const result = await getScanResult(id);
 
     if (!result) {
@@ -502,7 +503,7 @@ router.put(
   requireRole('STEWARD'),
   asyncHandler(async (req: Request, res: Response) => {
     const user = req.user;
-    const { id } = req.params;
+    const id = asString(req.params.id);
 
     if (!user) {
       return res.status(401).json({
@@ -584,7 +585,7 @@ router.put(
   requireRole('STEWARD'),
   asyncHandler(async (req: Request, res: Response) => {
     const user = req.user;
-    const { id } = req.params;
+    const id = asString(req.params.id);
     const { reason } = req.body;
 
     if (!user) {

--- a/researchflow-production-main/services/orchestrator/src/routes/visualization.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/visualization.ts
@@ -29,6 +29,7 @@ import { createFiguresService, type FigureCreateInput } from '../services/figure
 import { visualizationCache } from '../services/visualization-cache.service';
 import { visualizationMetrics } from '../services/visualization-metrics.service';
 import { createLogger } from '../utils/logger';
+import { asString } from '../utils/asString';
 
 const router = Router();
 const logger = createLogger('visualization-route');
@@ -532,7 +533,7 @@ router.get(
   '/visualization/figures/:researchId',
   requirePermission('VIEW'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { researchId } = req.params;
+    const researchId = asString(req.params.researchId);
     const { 
       figure_type, 
       phi_scan_status, 
@@ -597,7 +598,7 @@ router.get(
   '/visualization/figure/:id',
   requirePermission('VIEW'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     const { include_image = 'false' } = req.query;
 
     logger.info('Fetching figure', { figureId: id });
@@ -653,7 +654,7 @@ router.delete(
   '/visualization/figure/:id',
   requirePermission('DELETE'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
 
     logger.info('Deleting figure', { figureId: id });
 
@@ -713,7 +714,7 @@ router.get(
   '/visualization/stats/:researchId',
   requirePermission('VIEW'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { researchId } = req.params;
+    const researchId = asString(req.params.researchId);
 
     logger.info('Fetching figure statistics', { researchId });
 
@@ -758,7 +759,7 @@ router.patch(
   '/visualization/figure/:id/phi-scan',
   requirePermission('MODERATE'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     const { phi_scan_status, phi_risk_level, phi_findings } = req.body;
 
     logger.info('Updating PHI scan results', { 


### PR DESCRIPTION
## Summary

Apply `asString()` helper to 6 orchestrator route files covering PHI scanner, phase chat, docs-first features, and visualization.

Note: `replit_integrations/audio/routes.ts` and `replit_integrations/chat/routes.ts` from the original plan do not exist in the codebase — skipped.

## Files Changed (6)

| File | Errors Fixed | Params Wrapped |
|------|-------------|----------------|
| `phi-scanner.ts` | 6 | `id` |
| `docs-first/topic-briefs.ts` | 6 | `id` |
| `docs-first/ideas.ts` | 6 | `id` |
| `visualization.ts` | 5 | `researchId`, `id` |
| `phaseChatRoutes.ts` | 4 | `stage`, `agentId` |
| `docs-first/doc-kits.ts` | 2 | `id` |

## Typecheck Evidence

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Total errors | 405 | 373 | **-32** |
| TS2345 errors | 68 | 41 | **-27** |

## Cumulative Progress (all 6 batches)

| Metric | Original | Current | Total Reduced |
|--------|----------|---------|---------------|
| Total errors | 687 | 373 | **-314** |
| TS2345 | 317 | 41 | **-276** |
| Files fixed | — | 42 | — |

## Remaining TS2345 (41)

These are spread across non-route files (bridges, middleware, services, tests, packages) and represent different root causes (object shape mismatches, non-string|string[] arguments). They are out of scope for the `asString` route-params campaign.

Made with [Cursor](https://cursor.com)

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ✅ 1 no changes — [View all](https://hub.continue.dev/inbox?pr=https%3A%2F%2Fgithub.com%2Fry86pkqf74-rgb%2FROS_FLOW_2_1%2Fpull%2F157&utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->