### PR TITLE
fix(orch): Batch 9 — Governance, simulate, transparency TS fixes

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/routes/governance-simulate.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/governance-simulate.ts
@@ -10,7 +10,7 @@
 import { Router, Request, Response } from 'express';
 import * as z from 'zod';
 
-import { logAction } from '../services/auditService.js';
+import { logAction } from '../services/audit-service';
 
 const router = Router();
 
@@ -256,7 +256,7 @@ router.post('/simulate', async (req: Request, res: Response) => {
         id: 'custom',
         name: customScenario.name,
         description: customScenario.description || 'Custom simulation scenario',
-        actions: customScenario.actions,
+        actions: customScenario.actions as SimulationAction[],
       };
     } else if (scenarioId) {
       const builtIn = BUILT_IN_SCENARIOS.find((s) => s.id === scenarioId);
@@ -280,7 +280,8 @@ router.post('/simulate', async (req: Request, res: Response) => {
 
     // Log simulation
     await logAction({
-      action: 'GOVERNANCE_SIMULATION',
+      eventType: 'GOVERNANCE_SIMULATION',
+      action: 'SIMULATE',
       userId: user?.id || 'anonymous',
       resourceType: 'governance',
       resourceId: scenario.id,

--- a/researchflow-production-main/services/orchestrator/src/routes/governance.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/governance.ts
@@ -20,6 +20,7 @@ import { validateAuditChain } from '../services/auditService.js';
 import { eventBus } from '../services/event-bus';
 import { featureFlagsService } from '../services/feature-flags.service';
 import { governanceConfigService } from '../services/governance-config.service';
+import { asString } from '../utils/asString';
 
 // Simple async handler wrapper
 function asyncHandler(fn: (req: Request, res: Response, next: NextFunction) => Promise<void>) {
@@ -160,7 +161,7 @@ router.post(
 
     try {
       // Validate mode change is enabled via feature flag
-      const modeChangeEnabled = await featureFlagsService.isEnabled('allow_mode_changes');
+      const modeChangeEnabled = await featureFlagsService.isFlagEnabled('allow_mode_changes');
       if (!modeChangeEnabled) {
         res.status(403).json({
           error: 'Feature disabled',
@@ -474,7 +475,7 @@ router.post(
     }
 
     // Check if audit export is enabled via feature flag
-    const auditExportEnabled = await featureFlagsService.isEnabled('allow_audit_export');
+    const auditExportEnabled = await featureFlagsService.isFlagEnabled('allow_audit_export');
     if (!auditExportEnabled) {
       res.status(403).json({
         error: 'Feature disabled',
@@ -570,7 +571,7 @@ router.post(
     }
 
     // Check if approval workflow is enabled via feature flag
-    const approvalsEnabled = await featureFlagsService.isEnabled('allow_approvals');
+    const approvalsEnabled = await featureFlagsService.isFlagEnabled('allow_approvals');
     if (!approvalsEnabled) {
       res.status(403).json({
         error: 'Feature disabled',
@@ -654,7 +655,7 @@ router.post(
     }
 
     // Check if approval workflow is enabled via feature flag
-    const approvalsEnabled = await featureFlagsService.isEnabled('allow_approvals');
+    const approvalsEnabled = await featureFlagsService.isFlagEnabled('allow_approvals');
     if (!approvalsEnabled) {
       res.status(403).json({
         error: 'Feature disabled',
@@ -809,7 +810,7 @@ router.get(
   '/phi/reveal/:token',
   requireRole('STEWARD'),
   asyncHandler(async (req, res) => {
-    const { token } = req.params;
+    const token = asString(req.params.token);
 
     // In production, validate token against database
     // For now, just check if it looks valid

--- a/researchflow-production-main/services/orchestrator/src/routes/transparency.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/transparency.ts
@@ -213,11 +213,16 @@ router.post(
     `);
 
     // Emit event
-    eventBus.emit('transparency:bundle_created', {
-      bundleId: result.rows[0].id,
-      modelId: validated.model_id,
-      bundleType: validated.bundle_type,
-      createdBy: userId,
+    eventBus.publish({
+      type: 'transparency:bundle_created',
+      topic: 'governance',
+      ts: new Date().toISOString(),
+      payload: {
+        bundleId: result.rows[0].id,
+        modelId: validated.model_id,
+        bundleType: validated.bundle_type,
+        createdBy: userId,
+      },
     });
 
     res.status(201).json(result.rows[0]);
@@ -288,11 +293,16 @@ router.patch(
 
     // Emit status change event if applicable
     if (validated.status && validated.status !== current.status) {
-      eventBus.emit('transparency:bundle_status_changed', {
-        bundleId: id,
-        previousStatus: current.status,
-        newStatus: validated.status,
-        changedBy: userId,
+      eventBus.publish({
+        type: 'transparency:bundle_status_changed',
+        topic: 'governance',
+        ts: new Date().toISOString(),
+        payload: {
+          bundleId: id,
+          previousStatus: current.status,
+          newStatus: validated.status,
+          changedBy: userId,
+        },
       });
     }
 
@@ -323,9 +333,14 @@ router.delete(
       return;
     }
 
-    eventBus.emit('transparency:bundle_archived', {
-      bundleId: id,
-      archivedBy: userId,
+    eventBus.publish({
+      type: 'transparency:bundle_archived',
+      topic: 'governance',
+      ts: new Date().toISOString(),
+      payload: {
+        bundleId: id,
+        archivedBy: userId,
+      },
     });
 
     res.json({ message: 'Evidence bundle archived', bundle: result.rows[0] });


### PR DESCRIPTION
## Summary

Fixes 10 TypeScript errors across 3 governance-related files.

## Changes

### `governance.ts` (5 errors fixed)
- **TS2339 x4:** `featureFlagsService.isEnabled()` does not exist — replaced with `isFlagEnabled()` matching the actual export from `feature-flags.service.ts`
- **TS2339:** `token.startsWith()` fails on `string | string[]` — narrowed with `asString(req.params.token)`

### `governance-simulate.ts` (2 errors fixed)
- **TS2305:** `logAction` not exported from `auditService.js` — fixed import path to `audit-service` (hyphenated, the actual file)
- **TS2322:** Zod-parsed `customScenario.actions` has optional fields vs required `SimulationAction` — added type assertion (Zod validates presence)
- Also fixed `logAction` call to include required `eventType` field per `AuditLogEntry` interface

### `transparency.ts` (3 errors fixed)
- **TS2339 x3:** `eventBus.emit()` does not exist on `EventBus` — replaced with `eventBus.publish()` using the `AppEvent` shape (`{ type, topic: 'governance', ts, payload }`)

## Verification
- `npx tsc --noEmit` confirms zero errors in all 3 files
- No new errors introduced

Made with [Cursor](https://cursor.com)