### PR TITLE
fix(orch): Batch 10 — Faves eventBus + ai-feedback imports

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/routes/ai-feedback.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/ai-feedback.ts
@@ -9,7 +9,8 @@
  */
 
 import { aiOutputFeedback, aiInvocations } from '@researchflow/core/schema';
-import { eq, and, desc, gte, lte, sql, count } from 'drizzle-orm';
+import { eq, and, desc, gte, lte, sql } from 'drizzle-orm';
+import { count } from 'drizzle-orm/sql/functions/aggregate';
 import { Router, type Request, type Response } from 'express';
 
 import { db } from '../../db';
@@ -17,6 +18,7 @@ import { asyncHandler } from '../middleware/asyncHandler';
 import { requirePermission, requireRole } from '../middleware/rbac';
 import { rebuildFeedbackRAG } from '../services/ai-feedback-rag.service';
 import { logAction } from '../services/audit-service';
+import { asString } from '../utils/asString';
 
 const router = Router();
 
@@ -319,7 +321,7 @@ router.put(
   '/:id/review',
   requireRole('ADMIN'),
   asyncHandler(async (req: Request, res: Response) => {
-    const { id } = req.params;
+    const id = asString(req.params.id);
     const user = req.user;
 
     if (!user) {

--- a/researchflow-production-main/services/orchestrator/src/routes/faves.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/faves.ts
@@ -250,11 +250,16 @@ router.post(
       RETURNING *
     `);
 
-    eventBus.emit('faves:evaluation_created', {
-      evaluationId: result.rows[0].id,
-      modelId: validated.model_id,
-      evaluationType: validated.evaluation_type,
-      createdBy: userId,
+    eventBus.publish({
+      type: 'faves:evaluation_created',
+      topic: 'governance',
+      ts: new Date().toISOString(),
+      payload: {
+        evaluationId: result.rows[0].id,
+        modelId: validated.model_id,
+        evaluationType: validated.evaluation_type,
+        createdBy: userId,
+      },
     });
 
     res.status(201).json(result.rows[0]);
@@ -327,16 +332,26 @@ router.post(
 
     // Emit appropriate event
     if (deploymentAllowed) {
-      eventBus.emit('faves:evaluation_passed', {
-        evaluationId: id,
-        modelId: result.rows[0].model_id,
-        overallScore,
+      eventBus.publish({
+        type: 'faves:evaluation_passed',
+        topic: 'governance',
+        ts: new Date().toISOString(),
+        payload: {
+          evaluationId: id,
+          modelId: result.rows[0].model_id,
+          overallScore,
+        },
       });
     } else {
-      eventBus.emit('faves:evaluation_failed', {
-        evaluationId: id,
-        modelId: result.rows[0].model_id,
-        blockingIssues,
+      eventBus.publish({
+        type: 'faves:evaluation_failed',
+        topic: 'governance',
+        ts: new Date().toISOString(),
+        payload: {
+          evaluationId: id,
+          modelId: result.rows[0].model_id,
+          blockingIssues,
+        },
       });
     }
 
@@ -502,10 +517,15 @@ router.post(
       )
     `);
 
-    eventBus.emit('faves:override_requested', {
-      modelId,
-      requestedBy: userId,
-      reason,
+    eventBus.publish({
+      type: 'faves:override_requested',
+      topic: 'governance',
+      ts: new Date().toISOString(),
+      payload: {
+        modelId,
+        requestedBy: userId,
+        reason,
+      },
     });
 
     res.json({


### PR DESCRIPTION
## Summary

Fixes 6 TypeScript errors across 2 route files.

## Changes

### `faves.ts` (4 errors fixed)
- **TS2339 x4:** `eventBus.emit()` does not exist on `EventBus` — replaced with `eventBus.publish()` using the `AppEvent` shape (`{ type, topic: 'governance', ts, payload }`)

### `ai-feedback.ts` (2 errors fixed)
- **TS2305:** `count` not exported from `'drizzle-orm'` at top level — imported from `drizzle-orm/sql/functions/aggregate` where it's declared
- **TS2322:** `string | string[]` not assignable to `string` for `resourceId` — used `asString(req.params.id)` for narrowing

## Verification
- `npx tsc --noEmit` confirms zero errors in both files
- No new errors introduced

Made with [Cursor](https://cursor.com)