### PR TITLE
fix(orch): Batch 11 — Datasets classification casts + FormData typing

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/services/datasets-persistence.service.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/datasets-persistence.service.ts
@@ -6,7 +6,7 @@
  */
 
 import { datasets } from '@researchflow/core/schema';
-import { DatasetMetadata } from '@researchflow/core/types/classification';
+import { DatasetMetadata, type DataClassification } from '@researchflow/core/types/classification';
 import { eq, and, sql } from 'drizzle-orm';
 import { ilike } from "../db/drizzleCompat";
 
@@ -193,15 +193,16 @@ export async function createDataset(data: {
     const newDataset: DatasetMetadata = {
       id,
       name: data.filename,
-      classification: data.classification,
+      classification: data.classification as DataClassification,
       recordCount: data.rowCount || 0,
       uploadedAt: new Date(),
       uploadedBy: data.uploadedBy,
       phiScanPassed: false,
       schemaVersion: '1.0',
-      format: data.format,
+      format: data.format as DatasetMetadata['format'],
       sizeBytes: data.sizeBytes,
       columns: data.metadata?.columns || [],
+      source: data.metadata?.source || 'upload',
       riskScore: 0
     };
     mockDatasets.push(newDataset);
@@ -245,7 +246,7 @@ export async function updateDataset(
   if (!db) {
     const idx = mockDatasets.findIndex(d => d.id === id);
     if (idx >= 0) {
-      if (updates.classification) mockDatasets[idx].classification = updates.classification;
+      if (updates.classification) mockDatasets[idx].classification = updates.classification as DataClassification;
       if (updates.riskScore !== undefined) mockDatasets[idx].riskScore = updates.riskScore;
       return mockDatasets[idx];
     }


### PR DESCRIPTION
## Summary

Fixes 5 TypeScript errors across 2 service/route files.

## Changes

### `datasets-persistence.service.ts` (3 errors fixed)
- **TS2322 x3:** `string` not assignable to `DataClassification` or format union — added explicit casts at assignment sites where values have already been validated:
  - `data.classification as DataClassification`
  - `data.format as DatasetMetadata['format']`
  - `updates.classification as DataClassification`
- Imported `DataClassification` type from `@researchflow/core/types/classification`
- Added missing required `source` field with fallback `'upload'`

### `integrations-storage.ts` (2 errors fixed)
- **TS2554:** `form.append('file', contentBytes, { filename })` expected 2 args — the native `FormData.append()` has a 2-arg signature, but the code uses the `form-data` npm package (dynamic import) which supports 3 args
- **TS2339:** `form.getHeaders()` does not exist on native `FormData` — same root cause
- **Fix:** Typed the dynamic `form-data` import with an inline constructor shape that declares `.append(key, value, options)` and `.getHeaders()`, avoiding CJS `export =` + ESM dynamic import type conflicts

## Verification
- `npx tsc --noEmit` confirms zero errors in both files
- No new errors introduced

Made with [Cursor](https://cursor.com)