### PR TITLE
fix(orchestrator): Express union wraps in replit audio/chat routes (TS2345)

### DIFF
--- a/researchflow-production-main/services/orchestrator/replit_integrations/audio/routes.ts
+++ b/researchflow-production-main/services/orchestrator/replit_integrations/audio/routes.ts
@@ -2,6 +2,7 @@ import type { Express, Request, Response } from "express";
 
 import { chatStorage } from "../chat/storage";
 
+import { asString } from "../../src/utils/asString";
 import { openai, speechToText, voiceChatWithTextModel } from "./client";
 
 export function registerAudioRoutes(app: Express): void {
@@ -19,7 +20,7 @@ export function registerAudioRoutes(app: Express): void {
   // Get single conversation with messages
   app.get("/api/conversations/:id", async (req: Request, res: Response) => {
     try {
-      const id = parseInt(req.params.id);
+      const id = parseInt(asString(req.params.id));
       const conversation = await chatStorage.getConversation(id);
       if (!conversation) {
         return res.status(404).json({ error: "Conversation not found" });
@@ -47,7 +48,7 @@ export function registerAudioRoutes(app: Express): void {
   // Delete conversation
   app.delete("/api/conversations/:id", async (req: Request, res: Response) => {
     try {
-      const id = parseInt(req.params.id);
+      const id = parseInt(asString(req.params.id));
       await chatStorage.deleteConversation(id);
       res.status(204).send();
     } catch (error) {
@@ -61,7 +62,7 @@ export function registerAudioRoutes(app: Express): void {
   // For text model control, chain: speechToText() -> text model -> textToSpeech()
   app.post("/api/conversations/:id/messages", async (req: Request, res: Response) => {
     try {
-      const conversationId = parseInt(req.params.id);
+      const conversationId = parseInt(asString(req.params.id));
       const { audio, voice = "alloy", inputFormat = "wav" } = req.body;
 
       if (!audio) {
@@ -135,7 +136,7 @@ export function registerAudioRoutes(app: Express): void {
   // Supports multilingual sentence detection via locale parameter
   app.post("/api/conversations/:id/voice-stream", async (req: Request, res: Response) => {
     try {
-      const conversationId = parseInt(req.params.id);
+      const conversationId = parseInt(asString(req.params.id));
       const { audio, voice = "alloy", inputFormat = "wav", locale = "en" } = req.body;
 
       if (!audio) {

--- a/researchflow-production-main/services/orchestrator/replit_integrations/chat/routes.ts
+++ b/researchflow-production-main/services/orchestrator/replit_integrations/chat/routes.ts
@@ -1,6 +1,7 @@
 import type { Express, Request, Response } from "express";
 import OpenAI from "openai";
 
+import { asString } from "../../src/utils/asString";
 import { chatStorage } from "./storage";
 
 const openai = new OpenAI({
@@ -24,7 +25,7 @@ export function registerChatRoutes(app: Express): void {
   // Get single conversation with messages
   app.get("/api/conversations/:id", async (req: Request, res: Response) => {
     try {
-      const id = parseInt(req.params.id);
+      const id = parseInt(asString(req.params.id));
       const conversation = await chatStorage.getConversation(id);
       if (!conversation) {
         return res.status(404).json({ error: "Conversation not found" });
@@ -52,7 +53,7 @@ export function registerChatRoutes(app: Express): void {
   // Delete conversation
   app.delete("/api/conversations/:id", async (req: Request, res: Response) => {
     try {
-      const id = parseInt(req.params.id);
+      const id = parseInt(asString(req.params.id));
       await chatStorage.deleteConversation(id);
       res.status(204).send();
     } catch (error) {
@@ -64,7 +65,7 @@ export function registerChatRoutes(app: Express): void {
   // Send message and get AI response (streaming)
   app.post("/api/conversations/:id/messages", async (req: Request, res: Response) => {
     try {
-      const conversationId = parseInt(req.params.id);
+      const conversationId = parseInt(asString(req.params.id));
       const { content } = req.body;
 
       // Save user message


### PR DESCRIPTION
## Summary

Fixes **7 TypeScript TS2345 errors** in replit integrations: `req.params.id` is typed as `string | string[]`, which is not assignable to `parseInt()`'s `string` parameter.

## Approach

- Use the existing **`asString`** helper from `../../src/utils/asString` to normalize `req.params.id` to `string` before calling `parseInt()`.
- Same pattern already used elsewhere in the orchestrator (e.g. `workflow-stages.ts`, `phaseChatRoutes.ts`).

## Changes

| File | Updates |
|------|---------|
| `replit_integrations/audio/routes.ts` | Added `asString` import; wrapped `req.params.id` in `parseInt(asString(req.params.id))` at 4 call sites (lines 22, 50, 64, 138). |
| `replit_integrations/chat/routes.ts` | Added `asString` import; wrapped `req.params.id` in `parseInt(asString(req.params.id))` at 3 call sites (lines 27, 55, 67). |

## Verification

- No new linter issues in the modified files.
- Typecheck: the 7 errors in these two files are resolved.

**Effort:** ~10 min · **Risk:** None (type-only fix, no behavior change).

Made with [Cursor](https://cursor.com)