### PR TITLE
fix(storage): explicit SQL[] type for Drizzle ORM conditions (TS2345)

### DIFF
--- a/researchflow-production-main/services/orchestrator/storage.ts
+++ b/researchflow-production-main/services/orchestrator/storage.ts
@@ -46,6 +46,7 @@ import {
   fileUploads,
   researchSessions,
 } from "@researchflow/core/schema";
+import type { SQL } from "drizzle-orm/sql";
 import { eq, and, desc } from "drizzle-orm";
 
 import { db } from "./db";
@@ -424,7 +425,7 @@ export class DatabaseStorage implements IStorage {
     if (!db) {
       throw new Error('Database not initialized');
     }
-    const conditions = [];
+    const conditions: SQL[] = [];
     if (filters?.resourceId) conditions.push(eq(approvalGates.resourceId, filters.resourceId));
     if (filters?.status) conditions.push(eq(approvalGates.status, filters.status));
     if (filters?.requestedById) conditions.push(eq(approvalGates.requestedById, filters.requestedById));
@@ -498,7 +499,7 @@ export class DatabaseStorage implements IStorage {
     if (!db) {
       throw new Error('Database not initialized');
     }
-    const conditions = [];
+    const conditions: SQL[] = [];
     if (filters?.userId) conditions.push(eq(auditLogs.userId, filters.userId));
     if (filters?.action) conditions.push(eq(auditLogs.action, filters.action));
     if (filters?.resourceType) conditions.push(eq(auditLogs.resourceType, filters.resourceType));


### PR DESCRIPTION
## Summary
Fixes 7 TS2345 errors in `services/orchestrator/storage.ts` by adding explicit `SQL[]` type annotations to conditions arrays used with Drizzle ORM's `eq` and `and` functions.

## Problem
TypeScript inferred `const conditions = []` as `never[]` in `listApprovalGates` and `listAuditLogs`. Pushing `eq(...)` results caused TS2345 because the array type was incompatible.

## Solution
- Import `SQL` type from `drizzle-orm/sql`
- Declare `const conditions: SQL[] = []` in both methods
- Resolves all 7 TS2345 errors at lines 428-430 and 502-505

## BATCH 15 — Phase 1 TS2345 final sprint
- Effort: ~5 min
- Risk: None
- PR Ready: Immediate

Made with [Cursor](https://cursor.com)