### PR TITLE
fix(ts): use getClusterStatus().services for /cluster/services route (−2 errors)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/__tests__/phaseG.test.ts
+++ b/researchflow-production-main/services/orchestrator/src/__tests__/phaseG.test.ts
@@ -38,7 +38,8 @@ describe('ClusterStatusService (Task 116, 122)', () => {
   });
 
   it('should return services status', async () => {
-    const services = await clusterStatusService.getServicesStatus();
+    const status = await clusterStatusService.getClusterStatus();
+    const services = status.services;
 
     expect(services).toBeInstanceOf(Object);
     expect(Object.keys(services).length).toBeGreaterThan(0);

--- a/researchflow-production-main/services/orchestrator/src/routes/phaseG.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/phaseG.ts
@@ -50,7 +50,8 @@ router.get('/cluster/status', ...protectWithRole('STEWARD'), async (_req: Reques
 
 router.get('/cluster/services', ...protectWithRole('STEWARD'), async (_req: Request, res: Response) => {
   try {
-    const services = await clusterStatusService.getServicesStatus();
+    const status = await clusterStatusService.getClusterStatus();
+    const services = status.services;
     res.json({ success: true, data: services });
   } catch (error) {
     res.status(500).json({ success: false, error: (error as Error).message });


### PR DESCRIPTION
## Summary
Fixes semantic bug in `/cluster/services` route. The code was calling `getServicesStatus()` (typo, method does not exist) when it should call `getClusterStatus().services` to retrieve all services.

## The Problem
- Route is `/cluster/services` (plural) — needs **all services**
- Original code: `getServicesStatus()` — typo, does not exist
- Previous attempt: `getServiceStatus()` — wrong, expects a service name parameter for **one service**
- Correct fix: `getClusterStatus().services` — returns all services

## Changes
| File | Line | Change |
|------|------|--------|
| `phaseG.ts` | ~53 | `getServicesStatus()` → `getClusterStatus().services` |
| `phaseG.test.ts` | ~41 | `getServicesStatus()` → `getClusterStatus().services` |

## Error Count
- **Before:** 253 TS errors (baseline from main branch)
- **After:** 251 TS errors
- **Delta:** −2 errors

## Why This Fix
- `getServiceStatus(serviceName: string)` gets **one** service by name
- `getClusterStatus().services` gets **all** services (what the route needs)
- Maintains intended behavior: return all services for the `/cluster/services` endpoint

## Files Changed
2 files changed, 4 insertions(+), 2 deletions(-)

## Verification
```bash
# From main branch (baseline):
cd researchflow-production-main
npx tsc --noEmit --pretty false 2>&1 | grep "error TS" | wc -l
→ 253

# From fix/ts2551-method-name-typos (after fix):
cd researchflow-production-main
npx tsc --noEmit --pretty false 2>&1 | grep "error TS" | wc -l
→ 251

# TS2551 specifically:
npx tsc --noEmit --pretty false 2>&1 | grep "TS2551"
→ (no results - all TS2551 errors resolved)

# Verify typo removed:
grep -rn "getServicesStatus" --include="*.ts" | grep -v node_modules
→ (no results - typo completely removed)
```
