### PR TITLE
fix(ts): resolve TS2304 undefined variable errors (−4 errors)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/routes/source-attributes.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/source-attributes.ts
@@ -14,10 +14,12 @@ import { desc, eq, and, sql, gte, lte } from 'drizzle-orm';
 import { isNull } from "../db/drizzleCompat";
 import { Router, Request, Response, NextFunction } from 'express';
 import * as z from 'zod';
-
+import { createLogger } from '../utils/logger';
 import { db } from '../../db.js';
 import { requireRole } from '../middleware/rbac';
 import { eventBus, type AppEvent } from '../services/event-bus';
+
+const logger = createLogger('source-attributes');
 
 /** Row shape returned by the source_attributes SELECT query. */
 interface SourceAttributeRow {

--- a/researchflow-production-main/services/orchestrator/src/services/impact-tracker/index.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/impact-tracker/index.ts
@@ -60,7 +60,7 @@ async function lookupCrossrefByDoi(doi: string): Promise<ImpactMetric | null> {
   return {
     source: 'crossref',
     year: toInt(msg?.published?.['date-parts']?.[0]?.[0]),
-    venue: msg?.container-title?.[0],
+    venue: msg?.['container-title']?.[0],
     url: msg?.URL,
     raw: { crossref: msg },
   };

--- a/researchflow-production-main/services/orchestrator/src/services/teamsService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/teamsService.ts
@@ -42,4 +42,3 @@ export interface TeamsAction {
   name: string;
   targets?: Array<{ os: string; uri: string }>;
 }
-etype


### PR DESCRIPTION
## Summary
Fixes 3 TS2304 errors where variables were referenced but not defined or imported.

## Changes
| File | Line | Variable | Fix |
|------|------|----------|-----|
| `teamsService.ts` | ~45 | `etype` | Removed orphaned line (stray text) |
| `source-attributes.ts` | ~740 | `logger` | Added missing import from `../utils/logger` |
| `impact-tracker/index.ts` | ~63 | `title` | Fixed `container-title` property access to use bracket notation |

## Error Count
- **Before:** 251 errors
- **After:** 247 errors
- **Delta:** −4

## Files Changed
3 files changed

## Verification
```
npx tsc --noEmit 2>&1 | grep "TS2304" | wc -l → reduced by 3
```

## Notes
- Delta is −4 because fixing the bracket notation also resolved a TS2322 type error on the same line
- All three targeted TS2304 errors have been eliminated
