### PR TITLE
fix: enum alignment + type cast fixes (−4 TS errors, zero casts)

### DIFF
--- a/researchflow-production-main/packages/manuscript-engine/src/services/data-mapper.service.ts
+++ b/researchflow-production-main/packages/manuscript-engine/src/services/data-mapper.service.ts
@@ -58,7 +58,7 @@ export class DataMapperService {
           sentence += ` (p = ${this.formatPValue(test.pValue)})`;
         }
         if (test.confidenceInterval) {
-          sentence += `, 95% CI [${test.confidenceInterval.map(v => this.formatNumber(v)).join(', ')}]`;
+          sentence += `, 95% CI [${test.confidenceInterval.map((v: number) => this.formatNumber(v)).join(', ')}]`;
         }
         parts.push(sentence + '.');
       }


### PR DESCRIPTION
## PR G2: Enum Alignment + Type Cast Fixes

Resolves 4 TS errors across 2 files — separate from the Zod schema shape fixes in PR G1.

**Zero type assertions (`as`)** — all type safety derived from Zod schemas.

### Changes

| File | Errors Fixed | Approach |
|------|-------------|----------|
| `ai-router-bridge.ts` | 2× TS2345, 1× TS2322 | Derive `ModelTier` and `ModelOptions` from Zod schemas; parse routing API response via Zod; `safeParse` env var with fallback |
| `data-mapper.service.ts` | 1× TS2345 | Annotate `.map()` callback param `(v: number)` |

### How the casts were eliminated

**A) `ModelOptions` derived from Zod schema:**
```ts
const ModelOptionsSchema = z.object({ ... });
export type ModelOptions = z.infer<typeof ModelOptionsSchema>;
```
`parse()` output is now directly assignable — no `as ModelOptions` needed.

**B) Routing response parsed via Zod (not cast):**
```ts
const RoutingApiResponseSchema = z.object({
  selectedTier: ModelTierSchema,
  model: z.string(),
  costEstimate: z.object({ total: z.number() }),
});
const parsed = RoutingApiResponseSchema.parse(response.data);
```
Runtime-validated, no `as ModelTier`.

**C) `AI_DEFAULT_TIER` env var safely parsed:**
```ts
const parsedTier = ModelTierSchema.safeParse(process.env.AI_DEFAULT_TIER);
defaultTier: parsedTier.success ? parsedTier.data : 'MINI',
```
No `as ModelTier` — invalid values fall back to `'MINI'` at runtime.

### Verification
- Before (main): **199** errors
- After (this branch): **195** errors (−4)
- `npx tsc --noEmit 2>&1 | grep "TS2345" | grep -E "ai-router-bridge|data-mapper"` → **0 matches**
- `grep " as " ai-router-bridge.ts` → only `import * as z` and `error as Error`

### No runtime behavior changes — enum values resolve to the same strings, Zod parse adds runtime validation that wasn't there before.
