### PR TITLE
fix: return type alignment — organizations + lit-watcher (−7 TS2322 errors)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/literature/lit-watcher.routes.ts
+++ b/researchflow-production-main/services/orchestrator/src/literature/lit-watcher.routes.ts
@@ -107,7 +107,7 @@ router.get('/watchers/:manuscriptId', async (req: Request, res: Response) => {
 /**
  * Update a watcher
  */
-router.put('/watchers/:id', async (req: Request, res: Response) => {
+router.put('/watchers/:id', async (req: Request<{ id: string }>, res: Response) => {
   try {
     const { id } = req.params;
     const { query, frequency, sources, status } = req.body as UpdateWatcherRequest;
@@ -174,7 +174,7 @@ router.put('/watchers/:id', async (req: Request, res: Response) => {
 /**
  * Delete a watcher
  */
-router.delete('/watchers/:id', async (req: Request, res: Response) => {
+router.delete('/watchers/:id', async (req: Request<{ id: string }>, res: Response) => {
   try {
     const { id } = req.params;
     const userId = (req as any).user?.id;
@@ -282,7 +282,7 @@ router.put('/alerts/:id/status', async (req: Request, res: Response) => {
 /**
  * Run a watcher manually (trigger immediate search)
  */
-router.post('/watchers/:id/run', async (req: Request, res: Response) => {
+router.post('/watchers/:id/run', async (req: Request<{ id: string }>, res: Response) => {
   try {
     const { id } = req.params;
     const userId = (req as any).user?.id;

--- a/researchflow-production-main/services/orchestrator/src/routes/organizations.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/organizations.ts
@@ -245,7 +245,7 @@ router.patch(
   resolveOrgContext(),
   requireOrgId(),
   requireMinOrgRole("ADMIN"),
-  asyncHandler(async (req: Request, res: Response) => {
+  asyncHandler(async (req: Request<{ orgId: string }>, res: Response) => {
     const orgId = req.params.orgId;
     const userId = (req.user as any)?.id;
 
@@ -309,7 +309,7 @@ router.delete(
   resolveOrgContext(),
   requireOrgId(),
   requireMinOrgRole("OWNER"),
-  asyncHandler(async (req: Request, res: Response) => {
+  asyncHandler(async (req: Request<{ orgId: string }>, res: Response) => {
     const orgId = req.params.orgId;
     const userId = (req.user as any)?.id;
 
@@ -419,7 +419,7 @@ router.patch(
   resolveOrgContext(),
   requireOrgId(),
   requireOrgCapability("manage_members"),
-  asyncHandler(async (req: Request, res: Response) => {
+  asyncHandler(async (req: Request<{ orgId: string; memberId: string }>, res: Response) => {
     const { orgId, memberId } = req.params;
     const { orgRole } = req.body;
     const userId = (req.user as any)?.id;
@@ -491,7 +491,7 @@ router.delete(
   resolveOrgContext(),
   requireOrgId(),
   requireOrgCapability("manage_members"),
-  asyncHandler(async (req: Request, res: Response) => {
+  asyncHandler(async (req: Request<{ orgId: string; memberId: string }>, res: Response) => {
     const { orgId, memberId } = req.params;
     const userId = (req.user as any)?.id;
 


### PR DESCRIPTION
## PR H1: Return Type Mismatches

Resolves 7 TS2322 errors where route params don't match expected types.

### Error Summary

| File | Count | Fix |
|------|-------|-----|
| lit-watcher.routes.ts | 3 | Use Express generic `Request<{ id: string }>` |
| organizations.ts | 4 | Use Express generics for route params |

### Technical Details

Express route params have type `string | string[]` by default. Instead of using type assertions, properly type the route parameters using Express generics:

```typescript
// ✅ Correct approach (using generics)
router.put('/watchers/:id', async (req: Request<{ id: string }>, res: Response) => {
  const { id } = req.params;  // Type: string
  ...
});

asyncHandler(async (req: Request<{ orgId: string; memberId: string }>, res: Response) => {
  const { orgId, memberId } = req.params;  // Both type: string
  ...
});

// ❌ Avoid (type assertions)
const { id } = req.params as { id: string };
```

### Changes

**lit-watcher.routes.ts**:
- Line 110: `PUT /watchers/:id` handler
- Line 177: `DELETE /watchers/:id` handler  
- Line 285: `POST /watchers/:id/run` handler

**organizations.ts**:
- Line 247: `PUT /:orgId` handler
- Line 311: `DELETE /:orgId` handler
- Line 421: `PATCH /:orgId/members/:memberId` handler
- Line 493: `DELETE /:orgId/members/:memberId` handler

### Verification

- **Before (main)**: 195 errors
- **After (this branch)**: 188 errors (−7)

Targeted check:
```bash
npx tsc --noEmit 2>&1 | grep "TS2322" | grep -E "organizations|lit-watcher"
# No results (all fixed)
```

### Impact

- No behavior changes — route params were already strings at runtime
- Proper TypeScript typing using Express generics (no casts)
- Type safety improved — params correctly typed as string
- Callers unaffected — internal typing improvement only
