### PR TITLE
fix: service type narrowing — zero casts, proper guards (−3 TS2322)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/bridges/ai-router-bridge.ts
+++ b/researchflow-production-main/services/orchestrator/src/bridges/ai-router-bridge.ts
@@ -34,43 +34,7 @@ const ModelOptionsSchema = z.object({
 // Derive ModelOptions from the Zod schema — single source of truth
 export type ModelOptions = z.infer<typeof ModelOptionsSchema>;
 
-export interface LLMResponse {
-  content: string;
-  usage: {
-    totalTokens: number;
-    promptTokens: number;
-    completionTokens: number;
-  };
-  cost: {
-    total: number;
-    input: number;
-    output: number;
-  };
-  model: string;
-  tier: string;
-  finishReason: string;
-  metadata?: Record<string, any>;
-}
-
-export interface BridgeConfig {
-  orchestratorUrl: string;
-  defaultTier: ModelTier;
-  phiCompliantOnly: boolean;
-  maxRetries: number;
-  timeoutMs: number;
-  costTrackingEnabled: boolean;
-  streamingEnabled: boolean;
-}
-
-// Typed response from the AI Router routing endpoint
-const RoutingApiResponseSchema = z.object({
-  selectedTier: ModelTierSchema,
-  model: z.string(),
-  costEstimate: z.object({ total: z.number() }),
-});
-
-// ModelOptionsSchema and ModelOptions type are defined above the interfaces
-
+// LLMResponseSchema must be defined before the type that infers from it
 const LLMResponseSchema = z.object({
   content: z.string(),
   usage: z.object({
@@ -87,6 +51,25 @@ const LLMResponseSchema = z.object({
   tier: z.string(),
   finishReason: z.string(),
   metadata: z.record(z.any()).optional(),
+});
+
+export type LLMResponse = z.infer<typeof LLMResponseSchema>;
+
+export interface BridgeConfig {
+  orchestratorUrl: string;
+  defaultTier: ModelTier;
+  phiCompliantOnly: boolean;
+  maxRetries: number;
+  timeoutMs: number;
+  costTrackingEnabled: boolean;
+  streamingEnabled: boolean;
+}
+
+// Typed response from the AI Router routing endpoint
+const RoutingApiResponseSchema = z.object({
+  selectedTier: ModelTierSchema,
+  model: z.string(),
+  costEstimate: z.object({ total: z.number() }),
 });
 
 /**
@@ -399,7 +382,7 @@ export class AIRouterBridge {
         );
 
         // Validate and return response
-        const validated: LLMResponse = LLMResponseSchema.parse(response.data) as LLMResponse;
+        const validated = LLMResponseSchema.parse(response.data);
         return validated;
       } catch (error) {
         lastError = error as Error;

--- a/researchflow-production-main/services/orchestrator/src/clients/agentClient.ts
+++ b/researchflow-production-main/services/orchestrator/src/clients/agentClient.ts
@@ -844,6 +844,13 @@ class AgentClient {
     const self = this;
     let innerGen: AsyncGenerator<StreamEvent, void, unknown> | null = null;
 
+    // Type guard to narrow IteratorResult to the "yield" case
+    function isYield<T, TReturn>(
+      r: IteratorResult<T, TReturn>
+    ): r is IteratorYieldResult<T> {
+      return r.done === false;
+    }
+
     async function* wrap(): AsyncGenerator<StreamEvent, void, unknown> {
       innerGen = self._streamEvents(agentBaseUrl, path, body, options);
       if (!CIRCUIT_BREAKER_ENABLED) {
@@ -851,13 +858,13 @@ class AgentClient {
         return;
       }
       const first = await self.circuitBreaker.execute(() => innerGen!.next());
-      if (first.done) return;
-      yield first.value as StreamEvent;
+      if (!isYield(first)) return;
+      yield first.value;
       try {
         while (true) {
           const next = await innerGen!.next();
-          if (next.done) break;
-          yield next.value as StreamEvent;
+          if (!isYield(next)) break;
+          yield next.value;
         }
       } catch (err) {
         self.circuitBreaker.recordFailure();


### PR DESCRIPTION
## PR H2: Service Type Narrowing (Zero Casts)

Resolves 3 TS2322 errors across 2 service/client files using **proper type narrowing** — no `as` casts.

### Fix Pattern

#### A) ai-router-bridge.ts
- **Before**: Maintained separate `interface LLMResponse` and Zod schema, causing type mismatch
- **After**: Derive type from schema using `z.infer<typeof LLMResponseSchema>`
- **Benefit**: Single source of truth — schema defines both runtime validation and TypeScript type

```typescript
// Schema is now the authority
const LLMResponseSchema = z.object({ ... });
export type LLMResponse = z.infer<typeof LLMResponseSchema>;

// No cast needed — parse() returns the correct type
const validated = LLMResponseSchema.parse(response.data);
return validated;
```

#### B) agentClient.ts
- **Before**: Used `as StreamEvent` assertions after checking `done`
- **After**: Created `isYield<T, TReturn>()` type guard that narrows `IteratorResult` to `IteratorYieldResult<T>`
- **Benefit**: TypeScript understands the narrowing through the predicate function

```typescript
function isYield<T, TReturn>(
  r: IteratorResult<T, TReturn>
): r is IteratorYieldResult<T> {
  return r.done === false;
}

const first = await circuitBreaker.execute(() => innerGen!.next());
if (!isYield(first)) return;
yield first.value;  // TypeScript knows first.value is StreamEvent
```

### Changes

| File | Count | Before | After |
|------|-------|--------|-------|
| ai-router-bridge.ts | 1 | `interface LLMResponse` + cast | `type LLMResponse = z.infer<...>` |
| agentClient.ts | 2 | `as StreamEvent` assertions | `isYield()` type guard |

### Error Count
- **Before (main)**: 188 errors
- **After (this branch)**: 185 errors
- **Delta**: -3 ✓

### Verification
```bash
npx tsc --noEmit 2>&1 | grep "TS2322" | grep -E "agentClient|ai-router-bridge"
# No results = all fixed
```

### Notes
- **Zero type assertions** — TypeScript infers correctness through schema derivation and type guards
- **Better maintainability** — LLMResponse type automatically stays in sync with schema changes
- **Explicit narrowing** — `isYield()` makes the generator contract visible in code
