### PR TITLE
fix: align MockUser to AuthUser via type derivation, remove dead Express overrides (-3 TS2322)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/types/express.d.ts
+++ b/researchflow-production-main/services/orchestrator/src/types/express.d.ts
@@ -41,14 +41,11 @@ declare global {
       correlationId?: string;
       startTime?: number;
       
-      // Parsed body types (for JSON APIs)
-      body: Record<string, unknown>;
-      
-      // Query params (typed)
-      query: Record<string, string | string[] | undefined>;
-      
-      // Route params (typed)
-      params: Record<string, string>;
+      // NOTE: body, query, params are NOT declared here.
+      // Express.Request augmentation cannot override the generic properties
+      // on express.Request<P, ResBody, ReqBody, ReqQuery>.  Declaring them
+      // here is a no-op that silently lies about the actual types.
+      // See ParamsDictionary in @types/express-serve-static-core.
       
       // File uploads (multer)
       file?: Express.Multer.File;

--- a/researchflow-production-main/tests/utils/rbac-mock.ts
+++ b/researchflow-production-main/tests/utils/rbac-mock.ts
@@ -10,13 +10,15 @@ import type { Request, Response, NextFunction } from 'express';
 
 import type { Role } from '../../packages/core/types/roles';
 
-type AuthUserRole = 'admin' | 'researcher' | 'reviewer' | 'viewer';
+// Derive from Express.AuthUser so MockUser.role can never drift
+// (AuthUser is declared in services/orchestrator/src/types/express.d.ts)
+type AuthUserRole = NonNullable<Express.Request['user']>['role'];
 
 const ROLE_TO_AUTH_ROLE: Record<Role, AuthUserRole> = {
-  VIEWER: 'viewer',
-  RESEARCHER: 'researcher',
-  STEWARD: 'reviewer',
-  ADMIN: 'admin',
+  VIEWER: 'VIEWER',
+  RESEARCHER: 'RESEARCHER',
+  STEWARD: 'STEWARD',
+  ADMIN: 'ADMIN',
 };
 
 export interface MockUser {


### PR DESCRIPTION
## PR H3 (v2): Align types to reality — zero casts

### Root-cause analysis

Investigated all 14 remaining TS2322 errors and grouped them by root cause:

| Root cause | Errors | Status |
|---|---|---|
| **MockUser.role drifted from AuthUser.role** | 3 | **Fixed here** |
| Express ParamsDictionary types params as string or string[] | 3 | Separate PR (needs runtime guard) |
| Zod .optional() inference produces all-optional shapes | 3 | Separate PR (schema derivation) |
| Misc: readonly tuples, content optionality, headers, status union, role cast | 5 | Separate PRs by pattern |

### What this PR does

**Pattern: align types to reality (no casts, no asString)**

1. **rbac-mock.ts** — `MockUser.role` was `'admin' | 'researcher' | 'reviewer' | 'viewer'` (lowercase, wrong names). `AuthUser.role` is `'ADMIN' | 'RESEARCHER' | 'STEWARD' | 'VIEWER'`. Fixed by deriving `AuthUserRole` from `Express.Request['user']['role']` so the types can never drift again.

2. **express.d.ts** — Removed dead `body`, `query`, `params` declarations from the Express.Request augmentation. These were silently overridden by the generic parameters on `express.Request<P, ResBody, ReqBody, ReqQuery>` and served only to mislead. Root cause of the `string | string[]` params errors: Express's own `ParamsDictionary` types values as `string | string[]`, and our augmentation cannot override that.

### Why the other 11 errors are not in this PR

Each remaining group needs its own fix pattern:

- **string or string[]** (3 errors): Express ParamsDictionary genuinely types params as `string | string[]`. Fix requires either typed route generics or a runtime guard like `asString()`. That is a justified use of asString — but it is a different pattern, and belongs in its own PR.
- **Zod inference** (3 errors): Zod `.optional()` produces `{ name?: string }` even when `name: z.string()` is required inside. Fix is to derive service types from Zod schemas or add explicit `satisfies` checks. Different pattern, separate PR.
- **Misc** (5 errors): readonly tuples, optional content, HeadersInit spread, status union, role cast. No shared pattern — each should be a targeted single-file fix.

### Verification

```
Before (main): 185 errors
After:         182 errors (-3)
TS2322 in rbac-mock/test files: 0
New errors introduced: 0
```

### Files changed: 2 | Casts: 0 | asString: 0
