### PR TITLE
fix(ts): cache.config — spread readonly tuple to mutable array (-1 TS2322)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/config/cache.config.ts
+++ b/researchflow-production-main/services/orchestrator/src/config/cache.config.ts
@@ -326,7 +326,7 @@ export function shouldBypassCacheForAuth(path: string): boolean {
 export function getCacheInvalidationTargets(path: string): string[] {
   for (const [route, targets] of Object.entries(CACHE_INVALIDATION_RULES)) {
     if (route === path) {
-      return targets.invalidates;
+      return [...targets.invalidates];
     }
   }
   return [];


### PR DESCRIPTION
## What

Fix **1 TS2322** error in **cache.config.ts** using cast-free spread operator to convert readonly tuple to mutable array.

## Error fixed

| # | File | Line | Root cause | Fix |
|---|------|------|-----------|-----|
| 1 | `config/cache.config.ts` | 329 | `as const` produces `readonly` tuple, not assignable to mutable `string[]` | `return [...targets.invalidates]` — spread creates mutable copy |

## Detail

```typescript
// Before (TS2322)
return targets.invalidates;  // readonly tuple → string[] ❌

// After (no error)
return [...targets.invalidates];  // spread creates mutable copy ✓
```

The `CACHE_INVALIDATION_RULES` object uses `as const`, making `invalidates` property a readonly tuple. The function return type is `string[]` (mutable array), causing TS2322. Spreading the tuple creates a mutable copy.

## Verification

```bash
# MAIN_TOTAL (before this PR merges)
git checkout main && npx tsc --noEmit --pretty false 2>&1 | grep -c "error TS"
# → 176 errors

# AFTER_TOTAL (this PR branch)
git checkout fix/ts2322-misc-narrowing && npx tsc --noEmit --pretty false 2>&1 | grep -c "error TS"
# → 175 errors

# Ratchet check: 175 < 176 ✓

# Error eliminated
git checkout main && npx tsc --noEmit --pretty false 2>&1 | grep "cache\.config\.ts:329"
# → services/orchestrator/src/config/cache.config.ts(329,12): error TS2322: Type 'readonly ["/api/manuscript", "/api/research"] | ...' is not assignable to type 'string[]'

git checkout fix/ts2322-misc-narrowing && npx tsc --noEmit --pretty false 2>&1 | grep "cache\.config\.ts:329"
# → (empty)
```

## Stats

- **Files changed**: 1
- **Lines changed**: 1 insertion, 1 deletion
- **Error reduction**: -1 TS2322 (176 → 175)
- **Casts added**: 0
