### PR TITLE
fix: remove generic type params in notification-service.ts (-4 TS2558)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/collaboration/notification-service.ts
+++ b/researchflow-production-main/services/orchestrator/src/collaboration/notification-service.ts
@@ -208,7 +208,7 @@ export class NotificationService {
     const limit = Math.max(1, Math.min(100, opts.limit));
     const offset = Math.max(0, opts.offset);
 
-    const res = await this.pool.query<NotificationRow>(
+    const res = await this.pool.query(
       `SELECT id, user_id, type, title, body, link, metadata, read_at, created_at
        FROM notifications
        WHERE user_id = $1
@@ -243,7 +243,7 @@ export class NotificationService {
   }
 
   async getPreferences(userId: string): Promise<PreferencesRow> {
-    const res = await this.pool.query<PreferencesRow>(
+    const res = await this.pool.query(
       `SELECT user_id, email_digest, slack_mentions, in_app, digest_frequency
        FROM notification_preferences
        WHERE user_id = $1`,
@@ -253,7 +253,7 @@ export class NotificationService {
     if (res.rows.length > 0) return res.rows[0];
 
     // Default preferences (and create row for future updates)
-    const created = await this.pool.query<PreferencesRow>(
+    const created = await this.pool.query(
       `INSERT INTO notification_preferences (user_id)
        VALUES ($1)
        ON CONFLICT (user_id) DO UPDATE SET user_id = EXCLUDED.user_id
@@ -278,7 +278,7 @@ export class NotificationService {
       digest_frequency: patch.digest_frequency ?? current.digest_frequency,
     };
 
-    const res = await this.pool.query<PreferencesRow>(
+    const res = await this.pool.query(
       `INSERT INTO notification_preferences (user_id, email_digest, slack_mentions, in_app, digest_frequency)
        VALUES ($1, $2, $3, $4, $5)
        ON CONFLICT (user_id) DO UPDATE


### PR DESCRIPTION
## PR B: notification-service.ts TS2558 Generic Leftovers

Removes generic type parameters from 4 `pool.query<T>()` calls that triggered TS2558 ("Expected 0 type arguments, but got 1") in `notification-service.ts`.

### Pre-Execution Validation

Confirmed the following errors were present before applying fixes:
- [x] TS2558 at line 211 (`pool.query<NotificationRow>`)
- [x] TS2558 at line 246 (`pool.query<PreferencesRow>`)
- [x] TS2558 at line 256 (`pool.query<PreferencesRow>`)
- [x] TS2558 at line 281 (`pool.query<PreferencesRow>`)

### Root Cause

The `Pool.query` type definition in the project's `pg` types does not accept generic type arguments. These 4 calls used `query<NotificationRow>(...)` and `query<PreferencesRow>(...)` which produced TS2558. Same error class as PR #183.

### Fix

| Line | Before | After |
|------|--------|-------|
| 211 | `this.pool.query<NotificationRow>(...)` | `this.pool.query(...)` |
| 246 | `this.pool.query<PreferencesRow>(...)` | `this.pool.query(...)` |
| 256 | `this.pool.query<PreferencesRow>(...)` | `this.pool.query(...)` |
| 281 | `this.pool.query<PreferencesRow>(...)` | `this.pool.query(...)` |

### Verification

| Metric | Value |
|--------|-------|
| Baseline (main) | 169 errors |
| After (this branch) | 165 errors |
| Delta | **-4** |
| TS2558 remaining in notification-service.ts | **0** |
| New errors introduced | **0** |

### Mechanical removal of type parameters — no behavior change.

Made with [Cursor](https://cursor.com)