### PR TITLE
fix: phaseG.test.ts excess property errors (-2 TS2353)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/__tests__/phaseG.test.ts
+++ b/researchflow-production-main/services/orchestrator/src/__tests__/phaseG.test.ts
@@ -63,7 +63,6 @@ describe('PredictiveScalingService (Task 117)', () => {
   it('should predict scaling needs', async () => {
     const prediction = await predictiveScalingService.predictScaling({
       loadIncrease: 50,
-      affectedServices: ['web'],
     });
 
     expect(prediction).toBeDefined();
@@ -82,7 +81,7 @@ describe('PredictiveScalingService (Task 117)', () => {
 
   it('should compare scenarios', async () => {
     const results = await predictiveScalingService.compareScenarios([
-      { loadIncrease: 50, affectedServices: ['web'] },
+      { loadIncrease: 50 },
     ]);
     expect(results).toBeInstanceOf(Array);
   });


### PR DESCRIPTION
## PR C: phaseG.test.ts Excess Properties

Resolves 2 TS2353 errors where test fixtures include `affectedServices` which doesn't exist on the `ScalingScenario` stress-test options type.

### Pre-Execution Validation

- [x] TS2353 at line ~66 — `affectedServices` on stress-test options
- [x] TS2353 at line ~85 — `affectedServices` on stress-test options

### Fix Applied

- **Option B:** Removed `affectedServices` from both test fixtures

`affectedServices` is not part of the `ScalingScenario` type (which only has `loadIncrease`, `concurrentUsers`, `duration`). The `affectedServices` property in `devSimulationService.ts` is in a completely different context (simulation result metrics), not the scaling scenario input. Test fixtures should match the type, not the other way around.

### Verification

| Metric | Value |
|--------|-------|
| Baseline (main) | 165 errors |
| After (this branch) | 163 errors (**-2**) |
| TS2353 in phaseG.test remaining | **0** |
| phaseG tests passing | 56/57 (1 pre-existing failure unrelated to this change) |

Made with [Cursor](https://cursor.com)