### PR TITLE
fix: remove BullMQ v4 timeout in multiToolOrchestrator.ts (-1 TS2353)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/services/multiToolOrchestrator.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/multiToolOrchestrator.ts
@@ -297,7 +297,12 @@ export class MultiToolOrchestrator extends EventEmitter {
           priority: this.getPriorityValue(task.priority),
           attempts: task.retryStrategy?.maxRetries || 3,
           backoff: task.retryStrategy?.backoffMs || 5000,
-          timeout: task.timeout,
+          // TODO: BEHAVIOR CHANGE — per-job `timeout` removed (BullMQ v5 dropped
+          // it from JobsOptions). If task.timeout was set to a meaningful value,
+          // job execution is no longer time-bounded. lockDuration is NOT equivalent
+          // (it controls lock renewal, not "kill after X ms"). To restore per-job
+          // time limits, implement a worker-level cancellation or job watchdog.
+          // See: https://docs.bullmq.io/patterns/cancellation
         }
       );
 


### PR DESCRIPTION
## PR D: multiToolOrchestrator.ts BullMQ Leftover

Resolves 1 TS2353 error — `timeout` doesn't exist on BullMQ v5 `JobsOptions`.

### Pre-Execution Validation

- [x] TS2353 at line ~300 — `timeout` on `JobsOptions`

### Root Cause

BullMQ v5 removed per-job `timeout` from `JobsOptions`. Same migration class as PR #183 (Queue generics) and PR B (notification-service generics).

### Fix Applied

- **Option B (revised):** Removed `timeout` property. Added an explicit `TODO` comment that:
  - Calls out this is a **behavior change** — per-job time-bounding is now gone
  - Clarifies `lockDuration` is **not** equivalent (it controls lock renewal, not "kill after X ms")
  - Points to BullMQ cancellation patterns for restoring time limits if `task.timeout` was meaningful

### ⚠️ Behavior Note

If `task.timeout` was set to a non-null value in real usage, job execution is no longer time-bounded. The TODO in the code links to the BullMQ cancellation docs for implementing a worker-level equivalent. This is flagged as a follow-up outside the TS-stabilization scope.

### Verification

| Metric | Value |
|--------|-------|
| Baseline (main) | 163 errors |
| After (this branch) | 162 errors |
| Delta | **-1** |
| TS2353 in multiToolOrchestrator | **0** (was 1) |
| New errors introduced | **0** |

### Same BullMQ v5 migration pattern as PR #183 — mechanical property removal. Behavior change explicitly documented in code TODO.