### PR TITLE
fix: schema import resolution + AuthUser cleanup (-19 TS errors across 2 files)

### DIFF
--- a/researchflow-production-main/services/orchestrator/routes.ts
+++ b/researchflow-production-main/services/orchestrator/routes.ts
@@ -947,7 +947,6 @@ export async function registerRoutes(
       req.user = {
         ...req.user,
         id: user.id,
-        username: user.email || user.displayName,
         role: user.role || role,
         email: user.email,
       };
@@ -955,7 +954,6 @@ export async function registerRoutes(
       // Set default user context for public routes
       req.user = {
         id: 'anonymous',
-        username: 'anonymous',
         role: ROLES.VIEWER,
         email: 'anonymous@localhost',
       };

--- a/researchflow-production-main/services/orchestrator/src/types/researchflow-core.d.ts
+++ b/researchflow-production-main/services/orchestrator/src/types/researchflow-core.d.ts
@@ -86,6 +86,14 @@ declare module '@researchflow/core/schema' {
   export const userOnboarding: any;
   export const venues: any;
 
+  // TS2724 cluster fix: tables & schemas missing from initial .d.ts
+  export const topics: any;
+  export const analyticsEvents: any;
+  export const artifactEdges: any;
+  export const insertArtifactSchema: any;
+  export const insertArtifactVersionSchema: any;
+  export const insertArtifactComparisonSchema: any;
+
   // TS2305 cluster fix (PR150): const arrays / enums
   export const GOVERNANCE_MODES: readonly string[];
   export const ANALYTICS_EVENT_NAMES: readonly string[];
@@ -122,6 +130,12 @@ declare module '@researchflow/core/schema' {
   export type InsertFileUpload = any;
   export type ResearchSession = any;
   export type InsertResearchSession = any;
+
+  // TS2724 cluster fix: type exports missing from initial .d.ts
+  export type OrganizationRecord = any;
+  export type StatisticalPlanRecord = any;
+  export type ResearchBriefRecord = any;
+  export type InsertTopicBrief = any;
 
   // TS2305 cluster fix (PR150): type exports added after initial .d.ts authoring
   export type AnalyticsEventName = string;


### PR DESCRIPTION
## PR 1: Core/Schema Import Resolution

Resolves 16+ TypeScript errors (14 TS2724 + 2 TS2353) by fixing the root cause: the ambient `researchflow-core.d.ts` was missing exports that the actual `schema.ts` defines. Also fixes 3 cascading errors for a total of **-19 TS errors**.

### Root Cause

The `researchflow-core.d.ts` file provides ambient `declare module` declarations that override the actual `@researchflow/core/schema` module exports. It was missing 10 table/type exports, causing TS2724 errors in 10 consuming files.

### Pre-Execution Validation

Confirmed the following errors before applying fixes:
- [x] TS2724 ×4 in `routes.ts` (topics, insertArtifact*)
- [x] TS2724 ×5 across `topics.ts`, `topicService.ts`, `topic-briefs.service.ts`, `sap.ts`, `research-brief.ts` (topics)
- [x] TS2724 ×2 in `reproducibility-bundle.ts` (StatisticalPlanRecord, ResearchBriefRecord)
- [x] TS2724 ×1 each in `org-context.ts` (OrganizationRecord), `analytics.service.ts` (analyticsEvents), `artifactGraphService.ts` (artifactEdges)
- [x] TS2353 ×2 in `routes.ts` (username not in AuthUser)

### Fix Summary

**Added to `researchflow-core.d.ts`** (const exports):

| Missing Export | Consuming Files |
|---|---|
| `topics` | routes, topics, topicService, topic-briefs, sap, research-brief |
| `insertArtifactSchema` | routes |
| `insertArtifactVersionSchema` | routes |
| `insertArtifactComparisonSchema` | routes |
| `analyticsEvents` | analytics.service |
| `artifactEdges` | artifactGraphService |

**Added to `researchflow-core.d.ts`** (type exports):

| Missing Export | Consuming Files |
|---|---|
| `OrganizationRecord` | org-context |
| `StatisticalPlanRecord` | reproducibility-bundle |
| `ResearchBriefRecord` | reproducibility-bundle |
| `InsertTopicBrief` | topic-briefs.service |

**Removed from `routes.ts`**: `username` property from 2 AuthUser object literals (~lines 950, 958).

### Verification
- Baseline (main): **138** errors
- After (this branch): **119** errors (**-19**)
- 0 TS2724 in target files ✓
- 0 TS2353 username in routes.ts ✓
- No new errors introduced ✓

### Only 2 files changed — no import renames, no logic changes.

Made with [Cursor](https://cursor.com)