### PR TITLE
fix: export alias fixes — express-shim, EventBus, prom-client (-6 TS2724)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/services/event-bus.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/event-bus.ts
@@ -35,7 +35,7 @@ const REDIS_CHANNEL = 'researchflow:events';
  * - PHI-safe by design (validates event payloads)
  * - TypeScript-first with type-safe events
  */
-class EventBus {
+export class EventBus {
   private emitter: EventEmitter;
   private redisPublisher: net.Socket | null = null;
   private redisSubscriber: net.Socket | null = null;

--- a/researchflow-production-main/services/orchestrator/src/types/ambient.d.ts
+++ b/researchflow-production-main/services/orchestrator/src/types/ambient.d.ts
@@ -357,7 +357,7 @@ declare module 'bottleneck' {
     counts(): { RECEIVED: number; QUEUED: number; RUNNING: number; EXECUTING: number; DONE: number; RESERVOIR: number };
   }
 }
-declare module 'prom-client' { export const Registry: any; export const Counter: any; export const Gauge: any; export const Histogram: any; export const collectDefaultMetrics: any; }
+declare module 'prom-client' { export const register: any; export const Registry: any; export const Counter: any; export const Gauge: any; export const Histogram: any; export const collectDefaultMetrics: any; }
 declare module 'redis' {
   export type RedisClientType = any;
   export const createClient: any;

--- a/researchflow-production-main/services/orchestrator/src/types/express-shim.d.ts
+++ b/researchflow-production-main/services/orchestrator/src/types/express-shim.d.ts
@@ -25,6 +25,8 @@ declare namespace express {
   const request: core.Request;
   const response: core.Response;
 
+  type Application = core.Express;
+
   function Router(options?: core.RouterOptions): core.Router;
 }
 


### PR DESCRIPTION
## PR 2: Express-Shim + EventBus + Prom-Client Export Aliases

Resolves 6 TS2724 errors across 3 files. All are import/export mismatches — the consuming file imports a name the module doesn't export in that form.

### Pre-Execution Validation

Confirmed the following errors before applying fixes:
- [x] TS2724 ×4 — `Application` not exported from express-shim (`checklists.test`, `faves.test`, `manuscripts.audit.test`, `audit.test`)
- [x] TS2724 ×1 — `EventBus` not a named export from `event-bus.ts`
- [x] TS2724 ×1 — `register` not a named export from `prom-client` ambient declaration

### Fix Summary

| Root Cause | Fix Location | Consumer Files Fixed |
|-----------|-------------|---------------------|
| express-shim namespace missing `Application` type | `express-shim.d.ts` — add `type Application = core.Express` to namespace | 4 test files |
| EventBus class not exported | `event-bus.ts` — `export class EventBus` | 1 test file |
| prom-client ambient declaration missing `register` | `ambient.d.ts` — add `export const register: any` | 1 middleware file |

### Key Details

- The express-shim fix uses `core.Express` (not `core.Application`) in the namespace to match how test files use the type — they pass `app` to `supertest.request()` which expects `Express`
- The EventBus fix adds `export` to the class declaration; the singleton `eventBus` instance was already exported — now consumers can import either the class or the instance
- The prom-client fix adds `register` to the ambient type declaration (the real `@types/prom-client` exports it but the local ambient override was missing it)

### Verification

```
Baseline (main): 119 errors
After (this branch): 113 errors (-6)
Targeted TS2724 remaining: 0
New errors introduced: 0
```

Error diff confirms exactly 6 TS2724 removed, 0 new errors added.

### 3 edits resolve 6 errors. No logic changes. No test files modified.

Made with [Cursor](https://cursor.com)