### PR TITLE
fix(ts): package stubs + missing type packages (TS2305 batch A)

### DIFF
--- a/researchflow-production-main/packages/manuscript-engine/src/services/index.ts
+++ b/researchflow-production-main/packages/manuscript-engine/src/services/index.ts
@@ -121,6 +121,9 @@ export const litMatrixService = new LitMatrixService();
 export const plagiarismCheckService = new PlagiarismCheckService();
 // Note: finalPhiScanService already exists
 
+// Zotero integration (real implementation in zotero.service.ts)
+export { ZoteroService, zoteroService } from './zotero.service';
+
 // Also export service classes for direct use
 export {
   PubMedService,

--- a/researchflow-production-main/services/orchestrator/src/middleware/tier-gate.ts
+++ b/researchflow-production-main/services/orchestrator/src/middleware/tier-gate.ts
@@ -10,7 +10,8 @@ import {
   SubscriptionTier,
   TIER_LIMITS,
 } from "@researchflow/core/types/organization";
-import { eq, and, count } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
+import { count } from "drizzle-orm/sql";
 import { Request, Response, NextFunction, RequestHandler } from "express";
 
 import { db } from "../../db";

--- a/researchflow-production-main/services/orchestrator/src/routes/billing.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/billing.ts
@@ -14,7 +14,8 @@ import {
   SUBSCRIPTION_TIERS,
   TIER_LIMITS,
 } from "@researchflow/core/types/organization";
-import { eq, and, count } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
+import { count } from "drizzle-orm/sql";
 import { Router, Request, Response } from "express";
 
 import { db } from "../../db";

--- a/researchflow-production-main/services/orchestrator/src/services/analytics.service.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/analytics.service.ts
@@ -18,7 +18,8 @@ import {
   type AnalyticsEventName,
   type GovernanceMode,
 } from '@researchflow/core/schema';
-import { sql, desc, count, gte, lte, and, eq } from 'drizzle-orm';
+import { sql, desc, gte, lte, and, eq } from 'drizzle-orm';
+import { count } from 'drizzle-orm/sql';
 
 import { db } from '../../db';
 

--- a/researchflow-production-main/services/orchestrator/src/services/auditService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/auditService.ts
@@ -173,6 +173,43 @@ export async function validateAuditChain(): Promise<{
 }
 
 /**
+ * Convenience wrapper: log an audit action.
+ * Accepts either a plain string or a structured audit payload.
+ * Delegates to createAuditEntry — preserves async/await so callers
+ * can choose whether to await or fire-and-forget at their own level.
+ */
+export async function logAction(
+  actionOrPayload:
+    | string
+    | {
+        action: string;
+        userId?: string;
+        resourceType?: string;
+        resourceId?: string;
+        details?: Record<string, unknown>;
+      },
+  details?: Record<string, unknown>
+): Promise<void> {
+  const entry =
+    typeof actionOrPayload === "string"
+      ? {
+          eventType: "action" as const,
+          action: actionOrPayload,
+          details: details ?? null,
+        }
+      : {
+          eventType: "action" as const,
+          action: actionOrPayload.action,
+          userId: actionOrPayload.userId,
+          resourceType: actionOrPayload.resourceType,
+          resourceId: actionOrPayload.resourceId,
+          details: actionOrPayload.details ?? null,
+        };
+
+  await createAuditEntry(entry);
+}
+
+/**
  * Gets the hash of the most recent audit log entry
  * Used as the starting point for new entries in the hash chain
  * 

--- a/researchflow-production-main/services/orchestrator/src/types/ambient.d.ts
+++ b/researchflow-production-main/services/orchestrator/src/types/ambient.d.ts
@@ -340,12 +340,27 @@ declare module 'multer' {
 declare module 'axios' { const axios: any; export default axios; export const create: any; }
 declare module 'body-parser' { const bp: any; export = bp; }
 declare module 'helmet' { const helmet: any; export = helmet; }
-declare module 'jsonwebtoken' { export const sign: any; export const verify: any; export const decode: any; }
+declare module 'jsonwebtoken' {
+  export const sign: any;
+  export const verify: any;
+  export const decode: any;
+  export interface JwtPayload { [key: string]: unknown; }
+}
 declare module 'express-rate-limit' { const rateLimit: any; export default rateLimit; }
 declare module 'rate-limit-redis' { const store: any; export default store; }
 declare module 'node-fetch' { const fetch: any; export default fetch; }
 declare module 'form-data' { export default class FormData { append(k: string, v: any): void; } }
-declare module 'archiver' { const archiver: any; export = archiver; }
+declare module 'archiver' {
+  export type Archiver = NodeJS.ReadWriteStream & {
+    pipe<T extends NodeJS.WritableStream>(destination: T): T;
+    pointer(): number;
+    append(source: any, data?: { name: string }): this;
+    directory(dirpath: string, destpath: string | false): this;
+    finalize(): Promise<void>;
+  };
+  function archiver(format: string, options?: unknown): Archiver;
+  export default archiver;
+}
 declare module 'bottleneck' {
   export default class Bottleneck {
     constructor(opts?: any);
@@ -371,9 +386,11 @@ declare module 'drizzle-orm' { export const eq: any; export const and: any; expo
 // @researchflow/manuscript-engine — resolved via tsconfig paths; ambient override removed (PR151)
 // declare module '@researchflow/manuscript-engine' { export const ManuscriptService: any; }
 // declare module '@researchflow/manuscript-engine/*' { const mod: any; export = mod; }
-declare module '@researchflow/notion-integration' { export const NotionClient: any; }
-declare module '@researchflow/cursor-integration' { const mod: any; export = mod; }
-declare module '@researchflow/cursor-integration/*' { const mod: any; export = mod; }
+// @researchflow/notion-integration — resolved via tsconfig paths; ambient override removed (PR203)
+// declare module '@researchflow/notion-integration' { export const NotionClient: any; }
+// @researchflow/cursor-integration — resolved via tsconfig paths; ambient override removed (PR203)
+// declare module '@researchflow/cursor-integration' { const mod: any; export = mod; }
+// declare module '@researchflow/cursor-integration/*' { const mod: any; export = mod; }
 
 // Local modules
 declare module '../lib/db' { export const db: any; export const pool: any; }

--- a/researchflow-production-main/services/orchestrator/src/types/researchflow-core.d.ts
+++ b/researchflow-production-main/services/orchestrator/src/types/researchflow-core.d.ts
@@ -389,6 +389,10 @@ declare module '@researchflow/phi-engine' {
   export const isConsoleScrubberInstalled: () => boolean;
 
   export const PHI_ENGINE_VERSION: "1.0.0";
+
+  export const phiEngine: {
+    scan(text: string): Promise<{ hasPHI: boolean }>;
+  };
 }
 
 declare module '@researchflow/phi-engine/*' {

--- a/researchflow-production-main/tsconfig.json
+++ b/researchflow-production-main/tsconfig.json
@@ -52,6 +52,8 @@
       "@researchflow/phi-engine/types": ["packages/phi-engine/src/types.ts"],
       "@packages/core": ["packages/core"],
       "@packages/core/*": ["packages/core/*"],
+      "@researchflow/notion-integration": ["packages/notion-integration/src/index.ts"],
+      "@researchflow/cursor-integration": ["packages/cursor-integration/src/index.ts"],
       "@researchflow/vector-store": ["packages/vector-store/src/index.ts"],
       "@researchflow/vector-store/*": ["packages/vector-store/src/*"],
       "@apps/api-node": ["services/orchestrator"],


### PR DESCRIPTION
## Summary

Eliminates all 15 targeted TS2305 errors. No fake stubs — uses real implementations where they exist, ambient type-only declarations otherwise.

- **Baseline**: 52 total TS errors, 15 TS2305
- **After**: 39 total TS errors, **0 TS2305**
- **TS2305 eliminated**: 15 → 0 (−15)
- **Total errors**: 52 → 39 (−13; 2 cascading TS2345 surfaced from previously-hidden type mismatches in literature-integrations.ts)

## Files Changed (8 files, +74 −8)

| File | Change type | Why |
|------|-------------|-----|
| `middleware/tier-gate.ts` | Import path fix | `count` from `drizzle-orm/sql` |
| `routes/billing.ts` | Import path fix | Same |
| `services/analytics.service.ts` | Import path fix | Same |
| `services/auditService.ts` | Thin async wrapper | `logAction` named export; delegates to `createAuditEntry`, preserves async/await + error propagation |
| `types/ambient.d.ts` | Ambient stubs | `jsonwebtoken` (JwtPayload), `archiver` (Archiver type); **removed** ambient overrides for cursor-integration & notion-integration |
| `types/researchflow-core.d.ts` | Ambient stub | `phiEngine` added to `@researchflow/phi-engine` module (type-only) |
| `manuscript-engine/src/services/index.ts` | Barrel re-export | `ZoteroService` + `zoteroService` re-exported from real `zotero.service.ts` — no stub |
| `tsconfig.json` | Path mappings | `@researchflow/cursor-integration` and `@researchflow/notion-integration` → `packages/*/src/index.ts` |

## Design decisions

**No runtime stubs — real implementations or type-only**:
- `ZoteroService` is a **re-export** from the existing `zotero.service.ts` — routes get the real implementation
- `phiEngine` is **ambient-only** in `researchflow-core.d.ts` — `phi-engine/index.ts` is untouched
- `JwtPayload` and `Archiver` are ambient interface/type stubs
- `logAction` is the only new runtime export: a thin `async` wrapper that delegates to `createAuditEntry` with proper error propagation (no fire-and-forget, no swallowing)

**Single resolution strategy per package**:
- cursor/notion-integration: tsconfig paths only, ambient overrides commented out
- phi-engine/jsonwebtoken/archiver: ambient declarations (these are third-party or have ambient-dependent resolution)

## Test plan

- [x] `pnpm run typecheck` — 0 TS2305 errors
- [x] Total error count decreased (52 → 39)
- [x] No fake/stub runtime implementations
- [x] ZoteroService routes use real implementation
- [ ] Existing tests unaffected