### PR TITLE
fix(ts): resolve TS2554 extra arguments and TS2322 type mismatches (−5 errors)

### DIFF
--- a/researchflow-production-main/services/orchestrator/src/routes/semanticSearch.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/semanticSearch.ts
@@ -42,7 +42,7 @@ const requireSemanticSearch = asyncHandler(async (req: Request, res: Response, n
   }
 
   // Check feature flag
-  const enabled = await featureFlagsService.isFlagEnabled('semantic_search', org.id);
+  const enabled = await featureFlagsService.isFlagEnabled('semantic_search');
   if (!enabled) {
     return res.status(403).json({
       error: 'Semantic search is currently disabled',

--- a/researchflow-production-main/services/orchestrator/src/routes/tutorials.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/tutorials.ts
@@ -33,7 +33,7 @@ const tutorialStepSchema = z.object({
 const requireTutorialsEnabled = asyncHandler(async (req, res, next) => {
   const orgId = req.headers['x-organization-id'] as string || null;
 
-  const enabled = await featureFlagsService.isFlagEnabled('inline_tutorials', orgId);
+  const enabled = await featureFlagsService.isFlagEnabled('inline_tutorials');
   if (!enabled) {
     return res.status(403).json({
       error: 'Inline tutorials feature is currently disabled',

--- a/researchflow-production-main/services/orchestrator/src/services/aiEditingService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/aiEditingService.ts
@@ -290,7 +290,11 @@ export class AIEditingService {
         applied === 0
           ? "No high-confidence edits applied"
           : `Applied ${applied} suggestions across ${iterations} iteration(s)`,
-      sections: content.sections,
+      sections: content.sections
+        ? (Object.fromEntries(
+            Object.entries(content.sections).filter(([, v]) => v.content != null)
+          ) as Record<string, { content: string }>)
+        : undefined,
     };
   }
 

--- a/researchflow-production-main/services/orchestrator/src/services/dockerRegistryService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/dockerRegistryService.ts
@@ -65,7 +65,7 @@ async function dockerHubApiRequest<T>(
   try {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
-      ...options?.headers,
+      ...(options?.headers as Record<string, string>),
     };
 
     // Get token if authentication is required

--- a/researchflow-production-main/services/orchestrator/src/services/tutorialService.ts
+++ b/researchflow-production-main/services/orchestrator/src/services/tutorialService.ts
@@ -52,7 +52,7 @@ export class TutorialService {
     orgId: string | null
   ): Promise<TutorialAsset[]> {
     // Check feature flag
-    const flagEnabled = await featureFlagsService.isFlagEnabled('inline_tutorials', orgId);
+    const flagEnabled = await featureFlagsService.isFlagEnabled('inline_tutorials');
     if (!flagEnabled) {
       return [];
     }


### PR DESCRIPTION
## Summary
Fixes 3 TS2554 errors (extra arguments passed to functions) and 2 TS2322 errors (type assignment mismatches).

## Changes
| File | Line | Error | Fix |
|------|------|-------|-----|
| `semanticSearch.ts` | 45 | TS2554 | Remove extra `org.id` arg from `isFlagEnabled()` |
| `tutorials.ts` | 36 | TS2554 | Remove extra `orgId` arg from `isFlagEnabled()` |
| `tutorialService.ts` | 55 | TS2554 | Remove extra `orgId` arg from `isFlagEnabled()` |
| `aiEditingService.ts` | 293 | TS2322 | Filter + cast optional `content?` to required `content` |
| `dockerRegistryService.ts` | 66 | TS2322 | Cast `options?.headers` spread to `Record<string, string>` |

## Error Count
- **Before:** 12 errors
- **After:** 7 errors
- **Delta:** −5

## Files Changed
5 files changed

## Verification
```
npx tsc --noEmit 2>&1 | grep -E 'semanticSearch|tutorials\.ts|tutorialService|aiEditingService|dockerRegistryService' | grep -E 'TS2554|TS2322' | wc -l → 0
```

Made with [Cursor](https://cursor.com)