### PR TITLE
fix(ts): resolve TS2769 vitest + Playwright overload mismatches (−5 errors)

### DIFF
--- a/researchflow-production-main/packages/ai-router/vitest.config.ts
+++ b/researchflow-production-main/packages/ai-router/vitest.config.ts
@@ -3,32 +3,23 @@
  *
  * Configuration for Jest/Vitest tests:
  * - Test file discovery
- * - Module resolution
  * - Coverage settings
  * - Timeout configuration
  * - Mock setup
+ *
+ * Note: Module resolution aliases are handled by the root vitest.config.ts
+ * via vite-tsconfig-paths plugin.
  */
-
-import path from 'path';
 
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    // Environment
     environment: 'node',
-    
-    // Test file patterns
     include: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'src/__tests__/**/*.ts'],
     exclude: ['node_modules', 'dist', '.idea', '.git', '.cache'],
-
-    // Globals
     globals: true,
-
-    // Setup files
     setupFiles: [],
-
-    // Coverage configuration
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov', 'json-summary'],
@@ -36,42 +27,25 @@ export default defineConfig({
         'node_modules/',
         'src/__tests__/',
       ],
-      lines: 80,
-      functions: 80,
-      branches: 75,
-      statements: 80,
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 75,
+        statements: 80,
+      },
     },
-
-    // Test timeout (30 seconds)
     testTimeout: 30000,
     hookTimeout: 30000,
-
-    // Bail on first failure
     bail: 0,
-
-    // Include source maps
-    sourcemap: true,
-
-    // Reporter
-    reporter: ['default', 'html'],
+    reporters: ['default', 'html'],
     outputFile: {
       html: './test-report.html',
     },
-
-    // Mock configuration
     mockReset: true,
     restoreMocks: true,
     clearMocks: true,
-
-    // Snapshot settings
     snapshotFormat: {
       printBasicPrototype: true,
-    },
-  },
-
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
     },
   },
 });

--- a/researchflow-production-main/tests/e2e/ai-workflow.spec.ts
+++ b/researchflow-production-main/tests/e2e/ai-workflow.spec.ts
@@ -190,7 +190,7 @@ test.describe('AI Workflow - Full Execution', () => {
     let wsConnected = false;
     let lastAgentStatus = '';
 
-    const ws = await context.waitForEvent('websocket', async (ws) => {
+    const ws = await page.waitForEvent('websocket', (ws) => {
       if (ws.url().includes('ai') || ws.url().includes('workflow')) {
         wsConnected = true;
         console.log('✓ WebSocket connected:', ws.url());

--- a/researchflow-production-main/tests/e2e/artifact-browser.spec.ts
+++ b/researchflow-production-main/tests/e2e/artifact-browser.spec.ts
@@ -322,7 +322,7 @@ test.describe('VAL-003: Artifact Browser', () => {
 
     if (hasDownloadButton) {
       // Listen for download
-      const downloadPromise = context.waitForEvent('download');
+      const downloadPromise = page.waitForEvent('download');
 
       await downloadButton.click();
 

--- a/researchflow-production-main/tests/e2e/helpers/costCollector.ts
+++ b/researchflow-production-main/tests/e2e/helpers/costCollector.ts
@@ -15,7 +15,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
-import { Page, APIResponse } from '@playwright/test';
+import { Page, Response as PWResponse } from '@playwright/test';
 
 // =============================================================================
 // Types
@@ -62,7 +62,7 @@ export class CostCollector {
   private startTime: string = '';
   private testName: string = '';
   private maxBudgetUsd?: number;
-  private responseHandler?: (response: APIResponse) => Promise<void>;
+  private responseHandler?: (response: PWResponse) => Promise<void>;
 
   // AI endpoint patterns to monitor
   private readonly AI_ENDPOINT_PATTERNS = [
@@ -88,7 +88,7 @@ export class CostCollector {
     this.startTime = new Date().toISOString();
     this.calls = [];
 
-    this.responseHandler = async (response: APIResponse) => {
+    this.responseHandler = async (response: PWResponse) => {
       await this.handleResponse(response);
     };
 
@@ -112,7 +112,7 @@ export class CostCollector {
   /**
    * Handle a response and extract cost headers if present
    */
-  private async handleResponse(response: APIResponse): Promise<void> {
+  private async handleResponse(response: PWResponse): Promise<void> {
     const url = response.url();
 
     // Check if this is an AI endpoint


### PR DESCRIPTION
## Summary
Fixes 5 TS2769 errors caused by overload signature mismatches in vitest config and Playwright event handlers.

## Changes
| File | Line(s) | Fix |
|------|---------|-----|
| `packages/ai-router/vitest.config.ts` | config | Nest coverage thresholds under `thresholds`, rename `reporter`→`reporters`, remove invalid `sourcemap` property, remove `resolve` block (handled by root config's `vite-tsconfig-paths`) |
| `tests/e2e/helpers/costCollector.ts` | ~95, ~107 | Change `APIResponse`→`Response` (as `PWResponse`) for `page.on('response')` handler params |
| `tests/e2e/ai-workflow.spec.ts` | ~193 | Use `page.waitForEvent('websocket')` instead of `context.waitForEvent('websocket')` — websocket events are emitted on `Page`, not `BrowserContext` |
| `tests/e2e/artifact-browser.spec.ts` | ~325 | Use `page.waitForEvent('download')` instead of `context.waitForEvent('download')` — download events are emitted on `Page`, not `BrowserContext` |

## Error Count
- **Before:** 7 errors
- **After:** 2 errors
- **Delta:** −5

## Files Changed
4 files changed

## Verification
```
npx tsc --noEmit 2>&1 | grep -E 'vitest\.config|costCollector|ai-workflow\.spec|artifact-browser\.spec' | grep 'TS2769' | wc -l → 0
```

Made with [Cursor](https://cursor.com)