### PR TITLE
fix(ts): resolve final 2 TS2345 type mismatches in literature-integrations (−2 errors → 0 total)

### DIFF
--- a/researchflow-production-main/packages/manuscript-engine/src/services/index.ts
+++ b/researchflow-production-main/packages/manuscript-engine/src/services/index.ts
@@ -122,7 +122,7 @@ export const plagiarismCheckService = new PlagiarismCheckService();
 // Note: finalPhiScanService already exists
 
 // Zotero integration (real implementation in zotero.service.ts)
-export { ZoteroService, zoteroService } from './zotero.service';
+export { ZoteroService, zoteroService, type ZoteroConfig } from './zotero.service';
 
 // Also export service classes for direct use
 export {

--- a/researchflow-production-main/services/orchestrator/src/routes/literature-integrations.ts
+++ b/researchflow-production-main/services/orchestrator/src/routes/literature-integrations.ts
@@ -4,7 +4,7 @@
  */
 
 import { orgIntegrations } from '@researchflow/core/types/schema';
-import { ZoteroService, zoteroService } from '@researchflow/manuscript-engine/services';
+import { ZoteroService, zoteroService, type ZoteroConfig } from '@researchflow/manuscript-engine/services';
 import { eq, and } from 'drizzle-orm';
 import { Router, Request, Response } from 'express';
 import * as z from 'zod';
@@ -87,7 +87,8 @@ literatureIntegrationsRouter.post('/zotero/configure', async (req: Request, res:
     }
 
     // Configure the ZoteroService instance
-    zoteroService.configure(config);
+    // After safeParse success, all required fields are present; assert to match ZoteroConfig
+    zoteroService.configure(config as ZoteroConfig);
 
     res.json({ success: true, message: 'Zotero configured successfully' });
   } catch (error: any) {
@@ -160,7 +161,8 @@ literatureIntegrationsRouter.get('/zotero/collections', async (req: Request, res
 literatureIntegrationsRouter.get('/zotero/collections/:collectionKey/items', async (req: Request, res: Response) => {
   try {
     const orgId = (req as any).orgId;
-    const { collectionKey } = req.params;
+    // Express route params are always strings for named params
+    const collectionKey = req.params.collectionKey as string;
 
     const configured = await ensureZoteroConfigured(orgId);
     if (!configured) {


### PR DESCRIPTION
## Summary
Fixes the final 2 TypeScript errors in the codebase — both TS2345 argument type mismatches in the Zotero literature integration route.

## Changes
| File | Line | Fix |
|------|------|-----|
| `packages/manuscript-engine/src/services/index.ts` | export | Re-export `ZoteroConfig` type from `zotero.service.ts` |
| `services/orchestrator/src/routes/literature-integrations.ts` | 90 | Assert Zod `safeParse` output as `ZoteroConfig` after validation succeeds (Zod infers all fields as optional due to `.default()` on `libraryType`) |
| `services/orchestrator/src/routes/literature-integrations.ts` | 170 | Narrow `req.params.collectionKey` from `string \| string[]` to `string` (Express named route params are always strings) |

## Error Count
- **Before:** 2 errors
- **After:** 0 errors
- **Delta:** −2
- **Total remaining:** 0 🎉

## Files Changed
2 files changed

## Verification
```
npx tsc --noEmit 2>&1 | grep "error TS" | wc -l → 0
```

Made with [Cursor](https://cursor.com)