### PR TITLE
fix(test): exclude 5 node:test files from vitest runner

### DIFF
--- a/researchflow-production-main/vitest.config.ts
+++ b/researchflow-production-main/vitest.config.ts
@@ -40,6 +40,12 @@ export default defineConfig({
       'packages/**/__tests__/integration/**',
       'services/**/tests/integration/**',
       'services/**/__tests__/integration/**',
+      // node:test runner files — run separately via `node --test`
+      '**/security-crypto.test.ts',
+      '**/ai-bridge-e2e.test.ts',
+      '**/ai-bridge-production-validation.test.ts',
+      '**/ai-bridge-simple.test.ts',
+      '**/ai-bridge-llm.test.ts',
     ],
     testTimeout: 10000,
     coverage: {


### PR DESCRIPTION
## Summary

- **Excludes 5 test files** from vitest that use `import { describe, it } from 'node:test'` instead of vitest, which causes vitest to report "No test suite found"
- These files use `node:assert` patterns throughout and would need full rewrites to convert — they should be run separately via `node --test`
- Reduces failing test files from 21 → 16 and failing tests from 75 → 70

## Files excluded

| File | Location |
|------|----------|
| `security-crypto.test.ts` | `services/orchestrator/src/__tests__/` |
| `ai-bridge-e2e.test.ts` | `services/orchestrator/src/routes/__tests__/` |
| `ai-bridge-production-validation.test.ts` | `services/orchestrator/src/routes/__tests__/` |
| `ai-bridge-simple.test.ts` | `services/orchestrator/src/routes/__tests__/` |
| `ai-bridge-llm.test.ts` | `services/orchestrator/src/services/__tests__/` |

## What changed

Added glob patterns to the `exclude` array in `vitest.config.ts` with a comment explaining they use the node:test runner.

## Test plan

- [ ] `npx vitest --run` no longer reports "No test suite found" for these 5 files
- [ ] Remaining vitest tests still run as expected
- [ ] Excluded files can be run separately: `node --test services/orchestrator/src/__tests__/security-crypto.test.ts`

Made with [Cursor](https://cursor.com)