### PR TITLE
fix(deploy): SSH diagnostics + upgrade ssh-action to v1.2.0

### DIFF
--- a/.github/workflows/build-push-deploy-hetzner-fullstack.yml
+++ b/.github/workflows/build-push-deploy-hetzner-fullstack.yml
@@ -96,12 +96,26 @@ jobs:
     runs-on: ubuntu-latest
     environment: Hetzner production
     steps:
+      - name: Verify SSH secrets are set
+        run: |
+          if [ -z "${{ secrets.HETZNER_HOST }}" ]; then echo "::error::HETZNER_HOST secret is empty"; exit 1; fi
+          if [ -z "${{ secrets.HETZNER_USER }}" ]; then echo "::error::HETZNER_USER secret is empty"; exit 1; fi
+          if [ -z "${{ secrets.HETZNER_SSH_KEY }}" ]; then echo "::error::HETZNER_SSH_KEY secret is empty"; exit 1; fi
+          echo "All SSH secrets are set"
+
+      - name: Test host connectivity
+        run: |
+          echo "Testing connectivity to Hetzner..."
+          nc -z -w 10 ${{ secrets.HETZNER_HOST }} 22 && echo "Port 22 reachable" || echo "::warning::Port 22 not reachable"
+
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.HETZNER_HOST }}
           username: ${{ secrets.HETZNER_USER }}
           key: ${{ secrets.HETZNER_SSH_KEY }}
+          timeout: 30s
+          command_timeout: 10m
           script: |
             export IMAGE_TAG=sha-${{ github.sha }}
             bash /opt/researchflow/researchflow-production-main/tools/deploy/hetzner-fullstack-deploy.sh

--- a/.github/workflows/deploy-hetzner-gated.yml
+++ b/.github/workflows/deploy-hetzner-gated.yml
@@ -103,12 +103,26 @@ jobs:
     runs-on: ubuntu-latest
     environment: Hetzner production
     steps:
+      - name: Verify SSH secrets are set
+        run: |
+          if [ -z "${{ secrets.HETZNER_HOST }}" ]; then echo "::error::HETZNER_HOST secret is empty"; exit 1; fi
+          if [ -z "${{ secrets.HETZNER_USER }}" ]; then echo "::error::HETZNER_USER secret is empty"; exit 1; fi
+          if [ -z "${{ secrets.HETZNER_SSH_KEY }}" ]; then echo "::error::HETZNER_SSH_KEY secret is empty"; exit 1; fi
+          echo "All SSH secrets are set"
+
+      - name: Test host connectivity
+        run: |
+          echo "Testing connectivity to Hetzner..."
+          nc -z -w 10 ${{ secrets.HETZNER_HOST }} 22 && echo "Port 22 reachable" || echo "::warning::Port 22 not reachable"
+
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.HETZNER_HOST }}
           username: ${{ secrets.HETZNER_USER }}
           key: ${{ secrets.HETZNER_SSH_KEY }}
+          timeout: 30s
+          command_timeout: 10m
           script: |
             export IMAGE_TAG=sha-${{ github.event.workflow_run.head_sha }}
             bash /opt/researchflow/researchflow-production-main/tools/deploy/hetzner-fullstack-deploy.sh


### PR DESCRIPTION
## Problem
Deploy via SSH fails instantly (0s) on both fullstack runs #25 and #26.

## Changes
- Add secret verification step (catches empty secrets with clear error)
- Add host connectivity test (nc port 22 check before SSH attempt)
- Upgrade appleboy/ssh-action from v1.0.3 to v1.2.0
- Add explicit timeout (30s) and command_timeout (10m)
- Applied to both fullstack and gated workflows

This will give us clear diagnostic output to identify the root cause.